### PR TITLE
Make the clip and slice filters' output type consistent and documented

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1933,8 +1933,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and point/cell data of
-        the original mesh.
+        This will produce a deep copy of the points and of the point and field
+        data of the original mesh.
 
         Examples
         --------
@@ -1949,6 +1949,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
         pset.points = self.points.copy()
         out = self.cell_data_to_point_data() if pass_cell_data else self
         pset.GetPointData().DeepCopy(out.GetPointData())
+        pset.GetFieldData().DeepCopy(self.GetFieldData())
         field, name = out.active_scalars_info
         if field == FieldAssociation.POINT:
             pset.active_scalars_name = name
@@ -1972,8 +1973,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and point/cell data of
-        the original mesh.
+        This will produce a deep copy of the points and of the point and field
+        data of the original mesh.
 
         Examples
         --------
@@ -2011,6 +2012,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             cell_data = cell_data.cell_data_to_point_data()
             pset.GetCellData().DeepCopy(cell_data.GetPointData())
         pset.GetPointData().DeepCopy(self.GetPointData())
+        pset.GetFieldData().DeepCopy(self.GetFieldData())
         field, name = self.active_scalars_info
         if field == FieldAssociation.POINT or pass_cell_data:
             pset.active_scalars_name = name

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1933,8 +1933,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and of the point and field
-        data of the original mesh.
+        This will produce a deep copy of the points and of the point, cell and
+        field data of the original mesh.
 
         Examples
         --------
@@ -1973,8 +1973,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and of the point and field
-        data of the original mesh.
+        This will produce a deep copy of the points and of the point, cell and
+        field data of the original mesh.
 
         Examples
         --------

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3758,7 +3758,9 @@ class DataObjectFilters:
         alg.SetGenerateTriangles(generate_triangles)
         _update_alg(alg, progress_bar=progress_bar, message='Slicing')
         output = _get_output(alg)
-        if contour:
+        # There is nothing to contour when the plane misses, and the cutter can leave
+        # an empty output with no arrays for the contour to read
+        if contour and output.n_cells:
             return output.contour()
         return output
 
@@ -3897,7 +3899,7 @@ class DataObjectFilters:
             )
             # A plane that misses the image falls through to the cutter for its empty output
             if output is not None:
-                return output.contour() if contour else output
+                return output.contour() if contour and output.n_cells else output
         # create the plane for clipping
         implicit_function = generate_plane(normal_, origin_)
         return self.slice_implicit(
@@ -4292,7 +4294,9 @@ class DataObjectFilters:
             alg.GenerateTrianglesOff()
         _update_alg(alg, progress_bar=progress_bar, message='Slicing along Line')
         output = _get_output(alg)
-        if contour:
+        # There is nothing to contour when the plane misses, and the cutter can leave
+        # an empty output with no arrays for the contour to read
+        if contour and output.n_cells:
             return output.contour()
         return output
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -5636,7 +5636,27 @@ def _slice_image_along_axis(
     output.copy_meta_from(image, deep=True)
     output.field_data.update(image.field_data)
     output.set_active_scalars(image.active_scalars_name)
+    _copy_active_attributes(image, output)
     return output
+
+
+def _copy_active_attributes(source: DataSet, target: DataSet) -> None:
+    """Mark the same point and cell arrays active on ``target`` as on ``source``."""
+    for attributes_in, attributes_out in (
+        (source.point_data, target.point_data),
+        (source.cell_data, target.cell_data),
+    ):
+        for attr in (
+            'active_vectors_name',
+            'active_normals_name',
+            'active_texture_coordinates_name',
+        ):
+            name = getattr(attributes_in, attr)
+            if name is not None and name in attributes_out:
+                setattr(attributes_out, attr, name)
+        tensors = attributes_in.GetTensors()
+        if tensors is not None and tensors.GetName() in attributes_out:
+            attributes_out.SetActiveTensors(tensors.GetName())
 
 
 def _box_planes(bounds: NumpyArray[float]) -> list[tuple[VectorLike[float], VectorLike[float]]]:

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3243,7 +3243,9 @@ class DataObjectFilters:
             Set the clipping value along the normal direction.
 
         inplace : bool, default: False
-            Updates mesh in-place.
+            Updates mesh in-place. Only :class:`~pyvista.PolyData`,
+            :class:`~pyvista.PointSet` and :class:`~pyvista.UnstructuredGrid` inputs
+            support this; any other input raises ``TypeError``.
 
         return_clipped : bool, default: False
             Return both unclipped and clipped parts of the dataset.
@@ -3296,6 +3298,8 @@ class DataObjectFilters:
         See :ref:`clip_with_surface_example` for more examples using this filter.
 
         """
+        if inplace:
+            _validate_clip_inplace(self)
         origin_, normal_ = _validate_plane_origin_and_normal(
             self, origin, normal, plane, default_normal='x'
         )
@@ -5726,6 +5730,16 @@ def _clip_by_box_planes(
         append.AddInputData(piece)
     _update_alg(append, progress_bar=progress_bar, message='Clipping a Dataset by a Bounding Box')
     return _get_output(append)
+
+
+def _validate_clip_inplace(mesh: DataSet | MultiBlock) -> None:
+    """Raise when a clipped output cannot be copied back into its input mesh."""
+    if not isinstance(mesh, (pv.PolyData, pv.PointSet, pv.UnstructuredGrid)):
+        msg = (
+            f'Cannot use inplace=True for {type(mesh).__name__} input. Only PolyData, '
+            f'PointSet and UnstructuredGrid inputs can be clipped in place.'
+        )
+        raise TypeError(msg)
 
 
 def _remove_unused_points_post_clip(clip_output, input_bounds, *, force: bool = False):

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3270,11 +3270,12 @@ class DataObjectFilters:
         Returns
         -------
         output : DataSet | MultiBlock | tuple[DataSet | MultiBlock, DataSet | MultiBlock]
-            Clipped mesh when ``return_clipped=False`` or a tuple containing the
-            unclipped and clipped meshes. Output mesh type matches input type for
-            :class:`~pyvista.PointSet`, :class:`~pyvista.PolyData`, and
-            :class:`~pyvista.MultiBlock`; otherwise the output type is
-            :class:`~pyvista.UnstructuredGrid`.
+            Clipped mesh when ``return_clipped=False``, or a tuple of the kept and the
+            removed mesh when it is ``True``. A :class:`~pyvista.PolyData` gives a
+            ``PolyData`` and a :class:`~pyvista.PointSet` gives a ``PointSet``; every
+            other dataset gives an :class:`~pyvista.UnstructuredGrid`. A
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` whose blocks each follow
+            that rule, nested blocks included.
 
         Examples
         --------
@@ -3406,9 +3407,11 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.DataSet | pyvista.MultiBlock
-            Clipped dataset. Output mesh type matches the input type for
-            :class:`~pyvista.PointSet` and :class:`~pyvista.MultiBlock`; otherwise
-            the output type is :class:`~pyvista.UnstructuredGrid`.
+            Clipped dataset. A :class:`~pyvista.PointSet` gives a ``PointSet``, clipped
+            through its vertices; every other dataset, :class:`~pyvista.PolyData`
+            included, gives an :class:`~pyvista.UnstructuredGrid`. A
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` whose blocks each follow
+            that rule, nested blocks included.
 
         Examples
         --------
@@ -3588,10 +3591,11 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.DataSet | pyvista.MultiBlock
-            Clipped dataset. Output mesh type matches the input type for
-            :class:`~pyvista.PointSet`, :class:`~pyvista.PolyData`, and
-            :class:`~pyvista.MultiBlock`; otherwise the output type is
-            :class:`~pyvista.UnstructuredGrid`.
+            Clipped dataset. A :class:`~pyvista.PolyData` gives a ``PolyData`` and a
+            :class:`~pyvista.PointSet` gives a ``PointSet``; every other dataset gives
+            an :class:`~pyvista.UnstructuredGrid`. A
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` whose blocks each follow
+            that rule, nested blocks included.
 
         Raises
         ------
@@ -3697,8 +3701,15 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.PolyData | pyvista.MultiBlock
-            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
-            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
+            Sliced dataset. Every dataset gives a :class:`~pyvista.PolyData`, and a
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` of ``PolyData``
+            blocks, nested blocks included.
+
+        Notes
+        -----
+        A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
+        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
         --------
@@ -3821,8 +3832,9 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.PolyData | pyvista.MultiBlock
-            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
-            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
+            Sliced dataset. Every dataset gives a :class:`~pyvista.PolyData`, and a
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` of ``PolyData``
+            blocks, nested blocks included.
 
         Notes
         -----
@@ -3830,6 +3842,10 @@ class DataObjectFilters:
         :attr:`~pyvista.ImageData.direction_matrix` is sliced directly into quads, with
         point data interpolated between the two neighbouring grid planes. All other
         inputs use :vtk:`vtkCutter`.
+
+        A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
+        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
         --------
@@ -3932,7 +3948,14 @@ class DataObjectFilters:
         -------
         pyvista.MultiBlock
             Sliced dataset, with one :class:`~pyvista.PolyData` block per slice. A
-            :class:`~pyvista.MultiBlock` input gives one such ``MultiBlock`` per block.
+            :class:`~pyvista.MultiBlock` gives one such ``MultiBlock`` per block,
+            nested blocks included.
+
+        Notes
+        -----
+        A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
+        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
         --------
@@ -4061,7 +4084,14 @@ class DataObjectFilters:
         -------
         pyvista.MultiBlock
             Sliced dataset, with one :class:`~pyvista.PolyData` block per slice. A
-            :class:`~pyvista.MultiBlock` input gives one such ``MultiBlock`` per block.
+            :class:`~pyvista.MultiBlock` gives one such ``MultiBlock`` per block,
+            nested blocks included.
+
+        Notes
+        -----
+        A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
+        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
         --------
@@ -4181,8 +4211,15 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.PolyData | pyvista.MultiBlock
-            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
-            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
+            Sliced dataset. Every dataset gives a :class:`~pyvista.PolyData`, and a
+            :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` of ``PolyData``
+            blocks, nested blocks included.
+
+        Notes
+        -----
+        A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
+        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
         --------

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3358,7 +3358,6 @@ class DataObjectFilters:
         :class:`~pyvista.StructuredGrid`, :class:`~pyvista.ExplicitStructuredGrid`, and
         :class:`~pyvista.UnstructuredGrid`, are clipped by the six box planes in turn with
         the same clipper as :meth:`clip`, which keeps hexahedra and other cell types.
-        Passing ``merge_points=False`` clips any input with :vtk:`vtkBoxClipDataSet`.
 
         .. versionchanged:: 0.49
 
@@ -3367,7 +3366,8 @@ class DataObjectFilters:
               :class:`~pyvista.UnstructuredGrid` inputs are clipped by the six box planes
               instead of :vtk:`vtkBoxClipDataSet`, so cells the box does not cut keep their
               type instead of being split into tetrahedra, and the output normally has fewer
-              cells and points for the same clipped volume. Call
+              cells and points for the same clipped volume. This now also applies with
+              ``merge_points=False``, which no longer changes the cell type. Call
               :meth:`~pyvista.DataObjectFilters.triangulate` on the output for an
               all-tetrahedra mesh as before.
 
@@ -3395,8 +3395,7 @@ class DataObjectFilters:
 
         merge_points : bool, default: True
             If ``True``, coinciding points of independently defined mesh
-            elements will be merged. ``False`` clips with
-            :vtk:`vtkBoxClipDataSet`, whose output is split into tetrahedra.
+            elements will be merged.
 
         crinkle : bool, default: False
             Crinkle the clip by extracting the entire cells along the
@@ -3497,9 +3496,8 @@ class DataObjectFilters:
         # ImageData, RectilinearGrid, StructuredGrid, ExplicitStructuredGrid, and
         # UnstructuredGrid are clipped plane by plane instead, which keeps their cell types
         # and is faster for it. PolyData, and the vertices a PointSet is clipped as, are
-        # already triangulated and gain nothing from it, and only the box filter has a
-        # locator to disable for ``merge_points``.
-        use_box_filter = isinstance(self, pv.PolyData) or not merge_points
+        # already triangulated and gain nothing from it.
+        use_box_filter = isinstance(self, pv.PolyData)
         if use_box_filter:
             alg = _vtk.vtkBoxClipDataSet()
             if not merge_points:
@@ -3518,7 +3516,11 @@ class DataObjectFilters:
             clipped = _get_output(alg, oport=port)
         else:
             clipped = _clip_by_box_planes(
-                source, _box_planes(bounds_), invert=invert, progress_bar=progress_bar
+                source,
+                _box_planes(bounds_),
+                invert=invert,
+                merge_points=merge_points,
+                progress_bar=progress_bar,
             )
 
         if crinkle:
@@ -5727,6 +5729,7 @@ def _clip_by_box_planes(
     planes: Sequence[tuple[VectorLike[float], VectorLike[float]]],
     *,
     invert: bool,
+    merge_points: bool,
     progress_bar: bool,
 ) -> DataSet:
     """Clip by each plane in turn, keeping the inside or appending the outside pieces."""
@@ -5754,7 +5757,7 @@ def _clip_by_box_planes(
         # Nothing lay outside the box, so return an empty clip of the right type
         return inside.clip(normal=planes[0][0], origin=planes[0][1], invert=False)
     append = _vtk.vtkAppendFilter()
-    append.MergePointsOn()
+    append.SetMergePoints(merge_points)
     for piece in outside:
         append.AddInputData(piece)
     _update_alg(append, progress_bar=progress_bar, message='Clipping a Dataset by a Bounding Box')

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3358,6 +3358,7 @@ class DataObjectFilters:
         :class:`~pyvista.StructuredGrid`, :class:`~pyvista.ExplicitStructuredGrid`, and
         :class:`~pyvista.UnstructuredGrid`, are clipped by the six box planes in turn with
         the same clipper as :meth:`clip`, which keeps hexahedra and other cell types.
+        Passing ``merge_points=False`` clips any input with :vtk:`vtkBoxClipDataSet`.
 
         .. versionchanged:: 0.49
 
@@ -3394,7 +3395,8 @@ class DataObjectFilters:
 
         merge_points : bool, default: True
             If ``True``, coinciding points of independently defined mesh
-            elements will be merged.
+            elements will be merged. ``False`` clips with
+            :vtk:`vtkBoxClipDataSet`, whose output is split into tetrahedra.
 
         crinkle : bool, default: False
             Crinkle the clip by extracting the entire cells along the
@@ -3404,8 +3406,10 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.UnstructuredGrid
-            Clipped dataset.
+        pyvista.DataSet | pyvista.MultiBlock
+            Clipped dataset. Output mesh type matches the input type for
+            :class:`~pyvista.PointSet` and :class:`~pyvista.MultiBlock`; otherwise
+            the output type is :class:`~pyvista.UnstructuredGrid`.
 
         Examples
         --------
@@ -3689,8 +3693,9 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Sliced dataset.
+        pyvista.PolyData | pyvista.MultiBlock
+            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
+            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
 
         See Also
         --------
@@ -3803,8 +3808,9 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Sliced dataset.
+        pyvista.PolyData | pyvista.MultiBlock
+            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
+            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
 
         Notes
         -----
@@ -3912,8 +3918,9 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Sliced dataset.
+        pyvista.MultiBlock
+            Sliced dataset, with one :class:`~pyvista.PolyData` block per slice. A
+            :class:`~pyvista.MultiBlock` input gives one such ``MultiBlock`` per block.
 
         See Also
         --------
@@ -4045,8 +4052,9 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Sliced dataset.
+        pyvista.MultiBlock
+            Sliced dataset, with one :class:`~pyvista.PolyData` block per slice. A
+            :class:`~pyvista.MultiBlock` input gives one such ``MultiBlock`` per block.
 
         See Also
         --------
@@ -4170,8 +4178,9 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Sliced dataset.
+        pyvista.PolyData | pyvista.MultiBlock
+            Sliced dataset. A :class:`~pyvista.MultiBlock` input gives a
+            ``MultiBlock`` of :class:`~pyvista.PolyData` blocks.
 
         See Also
         --------

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3353,8 +3353,9 @@ class DataObjectFilters:
 
         If no bounds are given, a corner of the dataset bounds will be removed.
 
-        :class:`~pyvista.PolyData` and :class:`~pyvista.PointSet` inputs are clipped with
-        :vtk:`vtkBoxClipDataSet`, which splits the output into tetrahedra. All other inputs,
+        A :class:`~pyvista.PolyData` is clipped with :vtk:`vtkBoxClipDataSet`, which splits
+        the cells the box cuts into simplices, and a :class:`~pyvista.PointSet` is clipped
+        the same way through its vertices. All other inputs,
         that is :class:`~pyvista.ImageData`, :class:`~pyvista.RectilinearGrid`,
         :class:`~pyvista.StructuredGrid`, :class:`~pyvista.ExplicitStructuredGrid`, and
         :class:`~pyvista.UnstructuredGrid`, are clipped by the six box planes in turn with
@@ -3367,10 +3368,11 @@ class DataObjectFilters:
               :class:`~pyvista.UnstructuredGrid` inputs are clipped by the six box planes
               instead of :vtk:`vtkBoxClipDataSet`, so cells the box does not cut keep their
               type instead of being split into tetrahedra, and the output normally has fewer
-              cells and points for the same clipped volume. This now also applies with
-              ``merge_points=False``, which no longer changes the cell type. Call
-              :meth:`~pyvista.DataObjectFilters.triangulate` on the output for an
+              cells and points for the same clipped volume, whatever ``merge_points`` is.
+              Call :meth:`~pyvista.DataObjectFilters.triangulate` on the output for an
               all-tetrahedra mesh as before.
+            - A :class:`~pyvista.PolyData` input gives a ``PolyData`` instead of an
+              :class:`~pyvista.UnstructuredGrid`, with the same points and cells.
 
         Parameters
         ----------
@@ -3396,7 +3398,9 @@ class DataObjectFilters:
 
         merge_points : bool, default: True
             If ``True``, coinciding points of independently defined mesh
-            elements will be merged.
+            elements will be merged. It has no effect on the inputs clipped by
+            the box planes when ``invert=False``, which produce no coinciding
+            points to merge.
 
         crinkle : bool, default: False
             Crinkle the clip by extracting the entire cells along the
@@ -3407,9 +3411,9 @@ class DataObjectFilters:
         Returns
         -------
         pyvista.DataSet | pyvista.MultiBlock
-            Clipped dataset. A :class:`~pyvista.PointSet` gives a ``PointSet``, clipped
-            through its vertices; every other dataset, :class:`~pyvista.PolyData`
-            included, gives an :class:`~pyvista.UnstructuredGrid`. A
+            Clipped dataset. A :class:`~pyvista.PolyData` gives a ``PolyData`` and a
+            :class:`~pyvista.PointSet` gives a ``PointSet``, clipped through its
+            vertices; every other dataset gives an :class:`~pyvista.UnstructuredGrid`. A
             :class:`~pyvista.MultiBlock` gives a ``MultiBlock`` whose blocks each follow
             that rule, nested blocks included.
 
@@ -3528,7 +3532,8 @@ class DataObjectFilters:
 
         if crinkle:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
-        return _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
+        clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
+        return _cast_output_to_match_input_type(clipped, self)
 
     def clip_slab(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3467,6 +3467,20 @@ class DataObjectFilters:
                 crinkle=crinkle,
             )
 
+        if isinstance(self, pv.PointSet):
+            # vtkBoxClipDataSet clips cells, and a PointSet has none, so clip its vertices
+            return (
+                self.cast_to_poly_points()
+                .clip_box(
+                    bounds_,
+                    invert=invert,
+                    progress_bar=progress_bar,
+                    merge_points=merge_points,
+                    crinkle=crinkle,
+                )
+                .cast_to_pointset()
+            )
+
         source = self
         if crinkle:
             source, active_scalars_info = _Crinkler._add_cell_ids(self)

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3708,7 +3708,7 @@ class DataObjectFilters:
         Notes
         -----
         A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
-        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        raises :class:`~pyvista.core.errors.PointSetDimensionReductionError`. As a block of a
         :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
@@ -3844,7 +3844,7 @@ class DataObjectFilters:
         inputs use :vtk:`vtkCutter`.
 
         A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
-        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        raises :class:`~pyvista.core.errors.PointSetDimensionReductionError`. As a block of a
         :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
@@ -3954,7 +3954,7 @@ class DataObjectFilters:
         Notes
         -----
         A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
-        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        raises :class:`~pyvista.core.errors.PointSetDimensionReductionError`. As a block of a
         :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
@@ -4090,7 +4090,7 @@ class DataObjectFilters:
         Notes
         -----
         A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
-        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        raises :class:`~pyvista.core.errors.PointSetDimensionReductionError`. As a block of a
         :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also
@@ -4218,7 +4218,7 @@ class DataObjectFilters:
         Notes
         -----
         A :class:`~pyvista.PointSet` has no cells to slice, so slicing one directly
-        raises :class:`~pyvista.PointSetDimensionReductionError`. As a block of a
+        raises :class:`~pyvista.core.errors.PointSetDimensionReductionError`. As a block of a
         :class:`~pyvista.MultiBlock` it gives an empty block instead.
 
         See Also

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3490,7 +3490,8 @@ class DataObjectFilters:
         # UnstructuredGrid are clipped plane by plane instead, which keeps their cell types
         # and is faster for it. PolyData and PointSet are already triangulated, so they gain
         # nothing, and only the box filter has a locator to disable for ``merge_points``.
-        if isinstance(self, (pv.PolyData, pv.PointSet)) or not merge_points:
+        use_box_filter = isinstance(self, pv.PolyData) or not merge_points
+        if use_box_filter:
             alg = _vtk.vtkBoxClipDataSet()
             if not merge_points:
                 # vtkBoxClipDataSet uses vtkMergePoints by default
@@ -3513,7 +3514,7 @@ class DataObjectFilters:
 
         if crinkle:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
-        return _remove_unused_points_post_clip(clipped, self.bounds)
+        return _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
 
     def clip_slab(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,
@@ -5727,15 +5728,17 @@ def _clip_by_box_planes(
     return _get_output(append)
 
 
-def _remove_unused_points_post_clip(clip_output, input_bounds):
+def _remove_unused_points_post_clip(clip_output, input_bounds, *, force: bool = False):
     # VTK clip filters are buggy and sometimes retain unused points from the input, e.g.:
     # https://github.com/pyvista/pyvista/issues/6511
     # https://github.com/pyvista/pyvista/issues/7738
 
     def maybe_remove_unused_points(mesh: DataSet):
         # Unused points are correctly removed sometimes, so for performance we only
-        # remove points when the clipped bounds match input bounds
-        if np.allclose(clip_output.bounds, input_bounds) and hasattr(mesh, 'remove_unused_points'):
+        # remove points when the clipped bounds match input bounds, or when the caller
+        # knows its filter always keeps them
+        needed = force or np.allclose(clip_output.bounds, input_bounds)
+        if needed and hasattr(mesh, 'remove_unused_points'):
             return mesh.remove_unused_points()
         return mesh
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3496,8 +3496,9 @@ class DataObjectFilters:
         # Optimization: vtkBoxClipDataSet splits every cell into tetrahedra (VTK 9.7), so
         # ImageData, RectilinearGrid, StructuredGrid, ExplicitStructuredGrid, and
         # UnstructuredGrid are clipped plane by plane instead, which keeps their cell types
-        # and is faster for it. PolyData and PointSet are already triangulated, so they gain
-        # nothing, and only the box filter has a locator to disable for ``merge_points``.
+        # and is faster for it. PolyData, and the vertices a PointSet is clipped as, are
+        # already triangulated and gain nothing from it, and only the box filter has a
+        # locator to disable for ``merge_points``.
         use_box_filter = isinstance(self, pv.PolyData) or not merge_points
         if use_box_filter:
             alg = _vtk.vtkBoxClipDataSet()

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -4264,6 +4264,14 @@ class DataObjectFilters:
         >>> pl.show()
 
         """
+        # check that we have a PolyLine cell in the input line
+        if line.GetNumberOfCells() != 1:
+            msg = 'Input line must have only one cell.'
+            raise ValueError(msg)
+        polyline = line.GetCell(0)
+        if not isinstance(polyline, _vtk.vtkPolyLine):
+            msg = f'Input line must have a PolyLine cell, not ({type(polyline)})'
+            raise TypeError(msg)
         if isinstance(self, pv.MultiBlock):
             return _slice_each_block(
                 self,
@@ -4273,14 +4281,6 @@ class DataObjectFilters:
                 contour=contour,
                 progress_bar=progress_bar,
             )
-        # check that we have a PolyLine cell in the input line
-        if line.GetNumberOfCells() != 1:
-            msg = 'Input line must have only one cell.'
-            raise ValueError(msg)
-        polyline = line.GetCell(0)
-        if not isinstance(polyline, _vtk.vtkPolyLine):
-            msg = f'Input line must have a PolyLine cell, not ({type(polyline)})'
-            raise TypeError(msg)
         # Generate PolyPlane
         polyplane = _vtk.vtkPolyPlane()
         polyplane.SetPolyLine(polyline)

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3725,6 +3725,15 @@ class DataObjectFilters:
         >>> slice.plot(show_edges=True, line_width=5)
 
         """
+        if isinstance(self, pv.MultiBlock):
+            return _slice_each_block(
+                self,
+                'slice_implicit',
+                implicit_function,
+                generate_triangles=generate_triangles,
+                contour=contour,
+                progress_bar=progress_bar,
+            )
         alg = _vtk.vtkCutter()  # Construct the cutter object
         alg.SetInputDataObject(self)  # Use the grid as the data we desire to cut
         alg.SetCutFunction(implicit_function)  # the cutter to use the function
@@ -3948,22 +3957,17 @@ class DataObjectFilters:
             y = self.center[1]
         if z is None:
             z = self.center[2]
-        output = pv.MultiBlock()
         if isinstance(self, pv.MultiBlock):
-            for i in range(self.n_blocks):
-                data = self[i]
-                output.append(
-                    data.slice_orthogonal(
-                        x=x,
-                        y=y,
-                        z=z,
-                        generate_triangles=generate_triangles,
-                        contour=contour,
-                    )
-                    if data is not None
-                    else data
-                )
-            return output
+            return _slice_each_block(
+                self,
+                'slice_orthogonal',
+                x=x,
+                y=y,
+                z=z,
+                generate_triangles=generate_triangles,
+                contour=contour,
+            )
+        output = pv.MultiBlock()
         output.append(
             self.slice(
                 normal='x',
@@ -4113,24 +4117,19 @@ class DataObjectFilters:
         )
         center = list(center)
         # Make each of the slices
-        output = pv.MultiBlock()
         if isinstance(self, pv.MultiBlock):
-            for i in range(self.n_blocks):
-                data = self[i]
-                output.append(
-                    data.slice_along_axis(
-                        n=n,
-                        axis=ax_label,
-                        tolerance=tolerance,
-                        generate_triangles=generate_triangles,
-                        contour=contour,
-                        bounds=bounds,
-                        center=center,
-                    )
-                    if data is not None
-                    else data
-                )
-            return output
+            return _slice_each_block(
+                self,
+                'slice_along_axis',
+                n=n,
+                axis=ax_label,
+                tolerance=tolerance,
+                generate_triangles=generate_triangles,
+                contour=contour,
+                bounds=bounds,
+                center=center,
+            )
+        output = pv.MultiBlock()
         for i in range(n):
             center[ax_index] = rng[i]
             slc = self.slice(
@@ -4221,6 +4220,15 @@ class DataObjectFilters:
         >>> pl.show()
 
         """
+        if isinstance(self, pv.MultiBlock):
+            return _slice_each_block(
+                self,
+                'slice_along_line',
+                line,
+                generate_triangles=generate_triangles,
+                contour=contour,
+                progress_bar=progress_bar,
+            )
         # check that we have a PolyLine cell in the input line
         if line.GetNumberOfCells() != 1:
             msg = 'Input line must have only one cell.'
@@ -5609,6 +5617,17 @@ def _get_cell_quality_measures() -> dict[str, str]:
             measure_name = re.sub(r'([a-z])([A-Z])', r'\1_\2', measure_name).lower()
             measures[measure_name] = attr
     return measures
+
+
+def _slice_each_block(composite: MultiBlock, method: str, /, *args, **kwargs) -> MultiBlock:
+    """Apply a slice filter to every block, slicing a ``PointSet`` as its vertices."""
+
+    def slice_block(block: DataSet):  # numpydoc ignore=PR01
+        """Slice one block through the filter its own type supports."""
+        source = block.cast_to_polydata(deep=False) if isinstance(block, pv.PointSet) else block
+        return getattr(source, method)(*args, **kwargs)
+
+    return composite.generic_filter(slice_block)
 
 
 def _slice_image_along_axis(

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -36,6 +36,7 @@ from pyvista.core.filters import _match_points_dtype
 from pyvista.core.filters import _update_alg
 from pyvista.core.filters.data_object import DataObjectFilters
 from pyvista.core.filters.data_object import _cast_output_to_match_input_type
+from pyvista.core.filters.data_object import _validate_clip_inplace
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
 from pyvista.core.utilities.arrays import get_array
@@ -672,7 +673,9 @@ class DataSetFilters(DataObjectFilters):
             The range produces an output similar to an isovolume filter of ParaView.
 
         inplace : bool, default: False
-            Update mesh in-place.
+            Update mesh in-place. Only :class:`~pyvista.PolyData`,
+            :class:`~pyvista.PointSet` and :class:`~pyvista.UnstructuredGrid` inputs
+            support this; any other input raises ``TypeError``.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -726,6 +729,8 @@ class DataSetFilters(DataObjectFilters):
         >>> clipped.plot()
 
         """
+        if inplace:
+            _validate_clip_inplace(self)
         if isinstance(self, _vtk.vtkPolyData):
             alg: _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet = _vtk.vtkClipPolyData()  # type: ignore[unreachable]
         else:
@@ -756,9 +761,6 @@ class DataSetFilters(DataObjectFilters):
         _update_alg(alg, progress_bar=progress_bar, message='Clipping by a Scalar')
         result0 = _get_output(alg)
         if inplace:
-            if isinstance(self, pv.core.grid.ImageData):
-                msg = 'Cannot use inplace argument for ImageData type input.'
-                raise TypeError(msg)
             self.copy_from(result0, deep=False)
             result0 = self
         if not is_single_value:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -685,9 +685,11 @@ class DataSetFilters(DataObjectFilters):
 
         Returns
         -------
-        output : pyvista.PolyData | tuple
+        output : pyvista.DataSet | tuple[pyvista.DataSet, pyvista.DataSet]
             Clipped dataset if ``both=False``.  If ``both=True`` then
-            returns a tuple of both clipped datasets.
+            returns a tuple of both clipped datasets. Output mesh type matches the
+            input type for :class:`~pyvista.PolyData` and :class:`~pyvista.PointSet`;
+            otherwise the output type is :class:`~pyvista.UnstructuredGrid`.
 
         Examples
         --------
@@ -830,9 +832,8 @@ class DataSetFilters(DataObjectFilters):
         -------
         DataSet
             Clipped mesh. Output type matches input type for
-            :class:`~pyvista.PointSet`, :class:`~pyvista.PolyData`, and
-            :class:`~pyvista.MultiBlock`; otherwise the output type is
-            :class:`~pyvista.UnstructuredGrid`.
+            :class:`~pyvista.PointSet` and :class:`~pyvista.PolyData`; otherwise the
+            output type is :class:`~pyvista.UnstructuredGrid`.
 
         Examples
         --------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -687,9 +687,16 @@ class DataSetFilters(DataObjectFilters):
         -------
         output : pyvista.DataSet | tuple[pyvista.DataSet, pyvista.DataSet]
             Clipped dataset if ``both=False``.  If ``both=True`` then
-            returns a tuple of both clipped datasets. Output mesh type matches the
-            input type for :class:`~pyvista.PolyData` and :class:`~pyvista.PointSet`;
-            otherwise the output type is :class:`~pyvista.UnstructuredGrid`.
+            returns a tuple of both clipped datasets. A :class:`~pyvista.PolyData`
+            gives a ``PolyData`` and a :class:`~pyvista.PointSet` gives a ``PointSet``;
+            every other dataset gives an :class:`~pyvista.UnstructuredGrid`.
+
+        Notes
+        -----
+        This filter is not available on a :class:`~pyvista.MultiBlock`. Use
+        :meth:`~pyvista.DataObjectFilters.clip` or
+        :meth:`~pyvista.DataObjectFilters.clip_box` for a composite, or apply this
+        filter to each block with :meth:`~pyvista.CompositeFilters.generic_filter`.
 
         Examples
         --------
@@ -831,9 +838,16 @@ class DataSetFilters(DataObjectFilters):
         Returns
         -------
         DataSet
-            Clipped mesh. Output type matches input type for
-            :class:`~pyvista.PointSet` and :class:`~pyvista.PolyData`; otherwise the
-            output type is :class:`~pyvista.UnstructuredGrid`.
+            Clipped mesh. A :class:`~pyvista.PolyData` gives a ``PolyData`` and a
+            :class:`~pyvista.PointSet` gives a ``PointSet``; every other dataset gives
+            an :class:`~pyvista.UnstructuredGrid`.
+
+        Notes
+        -----
+        This filter is not available on a :class:`~pyvista.MultiBlock`. Use
+        :meth:`~pyvista.DataObjectFilters.clip` or
+        :meth:`~pyvista.DataObjectFilters.clip_box` for a composite, or apply this
+        filter to each block with :meth:`~pyvista.CompositeFilters.generic_filter`.
 
         Examples
         --------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2122,7 +2122,8 @@ class PolyDataFilters(DataSetFilters):
         Returns
         -------
         pyvista.PolyData
-            The clipped mesh.
+            The clipped mesh. The point and cell data of the input are not
+            carried over to it.
 
         Examples
         --------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2125,6 +2125,13 @@ class PolyDataFilters(DataSetFilters):
             The clipped mesh. The point and cell data of the input are not
             carried over to it.
 
+        Notes
+        -----
+        This filter is not available on a :class:`~pyvista.MultiBlock`. Use
+        :meth:`~pyvista.DataObjectFilters.clip` or
+        :meth:`~pyvista.DataObjectFilters.clip_box` for a composite, or apply this
+        filter to each block with :meth:`~pyvista.CompositeFilters.generic_filter`.
+
         Examples
         --------
         Clip a sphere in the negative Z direction centered at the origin.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -346,7 +346,10 @@ class PointSet(_PointSetBase, _vtk.vtkPointSet):
         else:
             for key, value in self.point_data.items():
                 pdata.point_data[key] = value
-        pdata.GetFieldData().DeepCopy(self.GetFieldData())
+        if deep:
+            pdata.GetFieldData().DeepCopy(self.GetFieldData())
+        else:
+            pdata.GetFieldData().ShallowCopy(self.GetFieldData())
         return pdata
 
     def cast_to_unstructured_grid(self) -> pv.UnstructuredGrid:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -346,6 +346,7 @@ class PointSet(_PointSetBase, _vtk.vtkPointSet):
         else:
             for key, value in self.point_data.items():
                 pdata.point_data[key] = value
+        pdata.GetFieldData().DeepCopy(self.GetFieldData())
         return pdata
 
     def cast_to_unstructured_grid(self) -> pv.UnstructuredGrid:

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -660,6 +660,26 @@ def test_slice_image_other_paths(kwargs):
     assert sliced.n_cells
 
 
+def test_slice_image_axis_aligned_keeps_active_attributes():
+    image = _image_for_slicing()
+    n_points = image.n_points
+    image.point_data['vectors'] = np.tile(np.arange(n_points, dtype=float)[:, None], (1, 3))
+    image.point_data['normals'] = np.tile([[0.0, 0.0, 1.0]], (n_points, 1))
+    image.point_data['tcoords'] = np.tile(np.linspace(0, 1, n_points)[:, None], (1, 2))
+    image.point_data['tensors'] = np.tile(np.arange(9, dtype=float), (n_points, 1))
+    image.point_data.active_vectors_name = 'vectors'
+    image.point_data.active_normals_name = 'normals'
+    image.point_data.active_texture_coordinates_name = 'tcoords'
+    image.GetPointData().SetActiveTensors('tensors')
+
+    sliced = image.slice('x')
+    assert sliced.point_data.active_vectors_name == 'vectors'
+    assert sliced.point_data.active_normals_name == 'normals'
+    assert sliced.point_data.active_texture_coordinates_name == 'tcoords'
+    assert sliced.GetPointData().GetTensors().GetName() == 'tensors'
+    assert sliced.point_data.active_scalars_name == 'floats'
+
+
 def test_slice_image_rotated_uses_cutter():
     image = _image_for_slicing()
     image.direction_matrix = pv.Transform().rotate_z(30).matrix[:3, :3]

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -276,11 +276,11 @@ def test_clip_box_output_type(multiblock_all_with_nested_and_none, crinkle):
     for dataset in multiblock_all_with_nested_and_none:
         clp = dataset.clip_box(invert=True, progress_bar=True, crinkle=crinkle)
         assert clp is not None
-        assert isinstance(clp, (pv.UnstructuredGrid, pv.MultiBlock, pv.PointSet))
+        assert isinstance(clp, (pv.UnstructuredGrid, pv.PolyData, pv.MultiBlock, pv.PointSet))
         if isinstance(clp, pv.MultiBlock):
-            # PointSet blocks stay PointSet, like a PointSet input does
+            # Every block keeps the class its own type gives, as a lone input does
             assert all(
-                isinstance(block, (pv.UnstructuredGrid, pv.PointSet))
+                isinstance(block, (pv.UnstructuredGrid, pv.PolyData, pv.PointSet))
                 for block in clp.recursive_iterator(skip_none=True)
             )
         clp2 = dataset.clip_box(merge_points=False)
@@ -351,7 +351,35 @@ def test_clip_box_no_unused_points(as_composite):
 def test_clip_box_polydata_no_unused_points(invert):
     mesh = pv.Sphere(theta_resolution=16, phi_resolution=16)
     clipped = mesh.clip_box([0.1, 1.0, 0.1, 1.0, 0.1, 1.0], invert=invert)
-    assert clipped.n_points == len(np.unique(clipped.cell_connectivity))
+    used = np.unique(clipped.cast_to_unstructured_grid().cell_connectivity)
+    assert clipped.n_points == len(used)
+
+
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_polydata_keeps_cells_and_arrays(invert):
+    """The output is the box filter's mesh in a PolyData, not a different mesh."""
+    mesh = pv.Sphere(theta_resolution=16, phi_resolution=16)
+    mesh.point_data['data'] = mesh.points[:, 2]
+    mesh.cell_data['cells'] = np.arange(mesh.n_cells, dtype=float)
+    bounds = [0.1, 1.0, 0.1, 1.0, 0.1, 1.0]
+
+    clipped = mesh.clip_box(bounds, invert=invert)
+    expected = _box_clip_filter(mesh, bounds, invert=invert).remove_unused_points()
+
+    assert type(clipped) is pv.PolyData
+    assert clipped.n_cells == expected.n_cells
+    assert clipped.area == pytest.approx(expected.area)
+    assert sorted(clipped.array_names) == sorted(expected.array_names)
+    assert np.allclose(np.sort(clipped.points, axis=0), np.sort(expected.points, axis=0))
+
+
+def test_clip_box_polydata_empty_is_polydata():
+    mesh = pv.Sphere(theta_resolution=8, phi_resolution=8)
+
+    clipped = mesh.clip_box([5.0, 6.0, 5.0, 6.0, 5.0, 6.0], invert=False)
+
+    assert type(clipped) is pv.PolyData
+    assert clipped.is_empty
 
 
 def test_clip_box_polydata_empty_output_has_no_points():
@@ -853,7 +881,7 @@ _CLIP_LIKE = {
     'ExplicitStructuredGrid': _GRID,
     'UnstructuredGrid': _GRID,
 }
-_BOX_LIKE = {**_CLIP_LIKE, 'PolyData': _GRID}
+_BOX_LIKE = _CLIP_LIKE
 _SLICE_LIKE = dict.fromkeys(_CLIP_LIKE, _POLY)
 _SLICES_LIKE = dict.fromkeys(_CLIP_LIKE, _MULTI)
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -404,6 +404,24 @@ def test_clip_box_planes_box_outside_or_containing_mesh(uniform):
     assert uniform.clip_box(far, invert=True).n_cells == uniform.n_cells
 
 
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_pointset(invert):
+    points = pv.PointSet(np.random.default_rng(0).random((200, 3)))
+    points.point_data['ids'] = np.arange(points.n_points)
+    points.field_data['meta'] = [1.0]
+    bounds = (0.0, 0.5, 0.0, 0.5, 0.0, 0.5)
+    inside = np.all((points.points >= 0.0) & (points.points <= 0.5), axis=1)
+
+    clipped = points.clip_box(bounds, invert=invert)
+
+    assert isinstance(clipped, pv.PointSet)
+    assert clipped.n_points == np.count_nonzero(~inside if invert else inside)
+    assert np.array_equal(
+        np.sort(clipped.point_data['ids']), np.flatnonzero(~inside if invert else inside)
+    )
+    assert np.allclose(clipped.field_data['meta'], [1.0])
+
+
 def test_clip_box_merge_points_false_uses_box_filter(uniform):
     clipped = uniform.clip_box(merge_points=False)
     assert set(clipped.celltypes) == {pv.CellType.TETRA}

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -134,8 +134,10 @@ def test_clip_filter_pointset_no_points_removed(pointset, as_composite):
 )
 def test_clip_inplace(mesh):
     mesh = mesh.copy()
+    n_points_in = mesh.n_points
     clipped = mesh.clip(inplace=True)
     assert clipped is mesh
+    assert mesh.n_points < n_points_in
 
 
 @pytest.mark.parametrize(
@@ -501,11 +503,14 @@ def test_clip_box_merge_points_keeps_cell_types(uniform, invert):
     assert set(merged.celltypes) == set(unmerged.celltypes)
     assert merged.n_cells == unmerged.n_cells
     assert merged.volume == pytest.approx(unmerged.volume)
-    assert merged.n_points <= unmerged.n_points
+    if invert:
+        # Only an inverted clip appends pieces that share points
+        assert merged.n_points < unmerged.n_points
+    else:
+        assert merged.n_points == unmerged.n_points
 
 
-@pytest.mark.parametrize('invert', [True, False])
-def test_clip_box_merge_points_false_keeps_coincident_points_apart(invert):
+def test_clip_box_merge_points_false_keeps_coincident_points_apart():
     grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
     centers = grid.cell_centers().points[:, 2]
     lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
@@ -525,7 +530,9 @@ def test_clip_box_merge_points_false_keeps_coincident_points_apart(invert):
 
     assert shared_across_seam(seam) == 0
     bounds = [2.5, 5.0, 2.5, 5.0, 2.5, 5.0]
-    assert shared_across_seam(seam.clip_box(bounds, invert=invert, merge_points=False)) == 0
+    # An inverted clip appends the pieces outside the box, welding the seam unless asked not to
+    assert shared_across_seam(seam.clip_box(bounds, invert=True)) > 0
+    assert shared_across_seam(seam.clip_box(bounds, invert=True, merge_points=False)) == 0
 
 
 def test_clip_box_composite(multiblock_all):
@@ -777,6 +784,17 @@ def test_slice_image_other_paths(kwargs):
     sliced = image.slice(**kwargs)
     assert isinstance(sliced, pv.PolyData)
     assert sliced.n_cells
+
+
+def test_slice_image_axis_aligned_keeps_active_cell_attributes():
+    image = _image_for_slicing()
+    n_cells = image.n_cells
+    image.cell_data['cell_vectors'] = np.tile(np.arange(n_cells, dtype=float)[:, None], (1, 3))
+    image.cell_data.active_vectors_name = 'cell_vectors'
+
+    sliced = image.slice('x')
+
+    assert sliced.cell_data.active_vectors_name == 'cell_vectors'
 
 
 def test_slice_image_axis_aligned_keeps_active_attributes():

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -811,54 +811,134 @@ def test_slice_filter_composite(multiblock_all):
     assert output.n_blocks == multiblock_all.n_blocks
 
 
-def _slice_call(mesh, name):
-    """Call one slice filter on a mesh with arguments that suit it."""
-    bounds = mesh.bounds
+def _output_type_meshes():
+    """Return one mesh of every wrappable class, all spanning the same bounds."""
+    axis = np.linspace(-1.0, 1.0, 5)
+    x, y, z = np.meshgrid(axis, axis, axis, indexing='ij')
+    explicit = pv.StructuredGrid(x, y, z)
+    explicit.dimensions = [5, 5, 5]
+    image = pv.ImageData(dimensions=(5, 5, 5), spacing=(0.5, 0.5, 0.5), origin=(-1, -1, -1))
+    return {
+        'PolyData': pv.Sphere(radius=1.0, theta_resolution=8, phi_resolution=8),
+        'PointSet': pv.PointSet(np.random.default_rng(0).uniform(-1, 1, (30, 3))),
+        'ImageData': image,
+        'RectilinearGrid': pv.RectilinearGrid(axis, axis, axis),
+        'StructuredGrid': pv.StructuredGrid(x, y, z),
+        'ExplicitStructuredGrid': explicit.cast_to_explicit_structured_grid(),
+        'UnstructuredGrid': image.cast_to_unstructured_grid(),
+    }
+
+
+def _output_type_call(mesh, name):
+    """Call one clip or slice filter with arguments valid for every input class."""
     kwargs = {
-        'slice': dict(normal=normals[0]),
-        'slice_implicit': dict(implicit_function=generate_plane((1.0, 0.0, 0.0), mesh.center)),
-        'slice_along_line': dict(
-            line=pv.Line(
-                (bounds.x_min, bounds.y_min, bounds.z_min),
-                (bounds.x_max, bounds.y_max, bounds.z_max),
-                resolution=10,
-            )
-        ),
+        'clip_slab': dict(normal='x', thickness=0.8),
+        'slice_implicit': dict(implicit_function=generate_plane((1.0, 0.0, 0.0), (0.0, 0.0, 0.0))),
         'slice_along_axis': dict(n=2),
+        'slice_along_line': dict(line=pv.Line((-2.0, -2.0, -2.0), (2.0, 2.0, 2.0), resolution=4)),
     }.get(name, {})
     return getattr(mesh, name)(**kwargs)
 
 
-@pytest.mark.parametrize(
-    'name',
-    ['slice', 'slice_implicit', 'slice_along_line', 'slice_orthogonal', 'slice_along_axis'],
-)
-def test_slice_filter_composite_pointset_block_is_empty(multiblock_all, name):
-    """Every slice filter gives an empty block for a ``PointSet``, which has no cells."""
-    pointset_index = next(
-        i for i, block in enumerate(multiblock_all) if isinstance(block, pv.PointSet)
+_GRID = pv.UnstructuredGrid
+_POLY = pv.PolyData
+_MULTI = pv.MultiBlock
+
+_CLIP_LIKE = {
+    'PolyData': _POLY,
+    'PointSet': pv.PointSet,
+    'ImageData': _GRID,
+    'RectilinearGrid': _GRID,
+    'StructuredGrid': _GRID,
+    'ExplicitStructuredGrid': _GRID,
+    'UnstructuredGrid': _GRID,
+}
+_BOX_LIKE = {**_CLIP_LIKE, 'PolyData': _GRID}
+_SLICE_LIKE = dict.fromkeys(_CLIP_LIKE, _POLY)
+_SLICES_LIKE = dict.fromkeys(_CLIP_LIKE, _MULTI)
+
+# The class each filter gives back for each input class, as the docstrings state it
+OUTPUT_TYPES = {
+    'clip': _CLIP_LIKE,
+    'clip_slab': _CLIP_LIKE,
+    'clip_box': _BOX_LIKE,
+    'slice': _SLICE_LIKE,
+    'slice_implicit': _SLICE_LIKE,
+    'slice_along_line': _SLICE_LIKE,
+    'slice_orthogonal': _SLICES_LIKE,
+    'slice_along_axis': _SLICES_LIKE,
+}
+
+
+@pytest.mark.parametrize('name', list(OUTPUT_TYPES))
+@pytest.mark.parametrize('mesh_type', list(_CLIP_LIKE))
+def test_clip_slice_output_type(name, mesh_type):
+    """Each filter gives back the class its docstring names, for every input class."""
+    mesh = _output_type_meshes()[mesh_type]
+
+    if mesh_type == 'PointSet' and name.startswith('slice'):
+        with pytest.raises(pv.PointSetDimensionReductionError):
+            _output_type_call(mesh, name)
+        return
+
+    output = _output_type_call(mesh, name)
+
+    expected = OUTPUT_TYPES[name][mesh_type]
+    assert type(output) is expected
+    if expected is _MULTI:
+        assert all(type(block) is _POLY for block in output)
+
+
+@pytest.mark.parametrize('name', list(OUTPUT_TYPES))
+def test_clip_slice_output_type_composite(name):
+    """A composite stays a composite, with every block following the same rule."""
+    meshes = _output_type_meshes()
+    flat, nested = list(meshes)[:3], list(meshes)[3:]
+    composite = pv.MultiBlock(
+        {
+            'flat': pv.MultiBlock({key: meshes[key] for key in flat}),
+            'nested': pv.MultiBlock({key: meshes[key] for key in nested}),
+            'empty': None,
+        }
     )
-    pointset = multiblock_all[pointset_index]
-    pointset.field_data['meta'] = [1.0]
 
-    block = _slice_call(multiblock_all, name)[pointset_index]
+    output = _output_type_call(composite, name)
 
-    blocks = block if isinstance(block, pv.MultiBlock) else [block]
-    for sliced in blocks:
-        assert isinstance(sliced, pv.PolyData)
-        assert sliced.is_empty
-        assert sliced.array_names == pointset.array_names
-        assert np.allclose(sliced.field_data['meta'], [1.0])
+    assert type(output) is _MULTI
+    assert output.keys() == composite.keys()
+    assert output['empty'] is None
+    for group, block_names in (('flat', flat), ('nested', nested)):
+        assert output[group].keys() == block_names
+        for mesh_type in block_names:
+            block = output[group][mesh_type]
+            expected = OUTPUT_TYPES[name][mesh_type]
+            assert type(block) is expected
+            if expected is _MULTI:
+                assert all(type(sub) is _POLY for sub in block)
+            if mesh_type == 'PointSet' and name.startswith('slice'):
+                blocks = block if isinstance(block, _MULTI) else [block]
+                assert all(sub.is_empty for sub in blocks)
 
 
 @pytest.mark.parametrize(
     'name',
     ['slice', 'slice_implicit', 'slice_along_line', 'slice_orthogonal', 'slice_along_axis'],
 )
-def test_slice_filter_pointset_raises(pointset, name):
-    """A ``PointSet`` on its own still refuses to be sliced."""
-    with pytest.raises(pv.PointSetDimensionReductionError):
-        _slice_call(pointset, name)
+def test_slice_composite_pointset_block_keeps_arrays(name):
+    """The empty block a PointSet gives still carries its arrays."""
+    points = pv.PointSet(np.random.default_rng(0).uniform(-1, 1, (30, 3)))
+    points.point_data['data'] = np.arange(points.n_points, dtype=float)
+    points.field_data['meta'] = [1.0]
+    points.set_active_scalars('data')
+
+    block = _output_type_call(pv.MultiBlock({'points': points}), name)['points']
+
+    for sliced in block if isinstance(block, _MULTI) else [block]:
+        assert type(sliced) is _POLY
+        assert sliced.is_empty
+        assert sliced.array_names == points.array_names
+        assert sliced.active_scalars_name == 'data'
+        assert np.allclose(sliced.field_data['meta'], [1.0])
 
 
 def test_slice_orthogonal_filter(datasets_no_pointset):
@@ -1250,24 +1330,6 @@ def test_slice_along_line_composite(multiblock_all):
     line = pv.Line(a, b, resolution=10)
     output = multiblock_all.slice_along_line(line, progress_bar=True)
     assert output.n_blocks == multiblock_all.n_blocks
-
-
-@pytest.mark.parametrize(
-    ('call', 'block_type'),
-    [
-        ('slice', pv.PolyData),
-        ('slice_implicit', pv.PolyData),
-        ('slice_along_line', pv.PolyData),
-        ('slice_orthogonal', pv.MultiBlock),
-        ('slice_along_axis', pv.MultiBlock),
-    ],
-)
-def test_slice_composite_output_type(multiblock_all, call, block_type):
-    output = _slice_call(multiblock_all, call)
-
-    assert isinstance(output, pv.MultiBlock)
-    assert output.n_blocks == multiblock_all.n_blocks
-    assert all(isinstance(block, block_type) for block in output)
 
 
 def test_slice_generate_triangles_true_emits_only_triangles():

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -466,9 +466,38 @@ def test_clip_box_pointset(invert):
     assert np.allclose(clipped.field_data['meta'], [1.0])
 
 
-def test_clip_box_merge_points_false_uses_box_filter(uniform):
-    clipped = uniform.clip_box(merge_points=False)
-    assert set(clipped.celltypes) == {pv.CellType.TETRA}
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_merge_points_keeps_cell_types(uniform, invert):
+    merged = uniform.clip_box(invert=invert)
+    unmerged = uniform.clip_box(invert=invert, merge_points=False)
+    assert set(merged.celltypes) == set(unmerged.celltypes)
+    assert merged.n_cells == unmerged.n_cells
+    assert merged.volume == pytest.approx(unmerged.volume)
+    assert merged.n_points <= unmerged.n_points
+
+
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_merge_points_false_keeps_coincident_points_apart(invert):
+    grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
+    centers = grid.cell_centers().points[:, 2]
+    lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
+    upper = grid.extract_cells(np.flatnonzero(centers > 2)).cast_to_unstructured_grid()
+    lower.cell_data['half'] = np.zeros(lower.n_cells)
+    upper.cell_data['half'] = np.ones(upper.n_cells)
+    # The halves meet at z == 2 but share no points, so the seam is a discontinuity
+    seam = lower.merge(upper, merge_points=False)
+
+    def shared_across_seam(mesh):
+        half = np.asarray(mesh.cell_data['half'])
+        halves_of_point = {}
+        for i in range(mesh.n_cells):
+            for point_id in mesh.get_cell(i).point_ids:
+                halves_of_point.setdefault(point_id, set()).add(round(float(half[i])))
+        return sum(1 for halves in halves_of_point.values() if len(halves) > 1)
+
+    assert shared_across_seam(seam) == 0
+    bounds = [2.5, 5.0, 2.5, 5.0, 2.5, 5.0]
+    assert shared_across_seam(seam.clip_box(bounds, invert=invert, merge_points=False)) == 0
 
 
 def test_clip_box_composite(multiblock_all):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1322,6 +1322,16 @@ def test_sample_composite():
     assert 'vtkGhostType' in result[0].point_data
 
 
+@pytest.mark.parametrize('as_composite', [True, False])
+def test_slice_along_line_bad_line_raises(as_composite):
+    mesh = pv.Sphere()
+    mesh = pv.MultiBlock([mesh]) if as_composite else mesh
+    with pytest.raises(ValueError, match='Input line must have only one cell'):
+        mesh.slice_along_line(pv.Line() + pv.Line((1, 1, 1), (2, 2, 2)))
+    with pytest.raises(TypeError, match='Input line must have a PolyLine cell'):
+        mesh.slice_along_line(pv.PolyData([[0.0, 0.0, 0.0]]))
+
+
 def test_slice_along_line():
     model = examples.load_uniform()
     n = 5

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1388,6 +1388,44 @@ def test_slice_along_line_composite(multiblock_all):
     assert output.n_blocks == multiblock_all.n_blocks
 
 
+@pytest.mark.parametrize('generate_triangles', [True, False])
+@pytest.mark.parametrize('name', ['slice', 'slice_implicit', 'slice_along_line'])
+def test_slice_contour_of_an_empty_slice(name, generate_triangles):
+    """A plane that cuts nothing has nothing to contour, arrays or not."""
+    points = pv.PolyData(np.random.default_rng(0).uniform(-1, 1, (30, 3)))
+    points.point_data['data'] = np.arange(points.n_points, dtype=float)
+
+    sliced = _output_type_call_with(
+        points, name, generate_triangles=generate_triangles, contour=True
+    )
+
+    assert type(sliced) is pv.PolyData
+    assert sliced.is_empty
+
+
+def _output_type_call_with(mesh, name, **kwargs):
+    """Call one slice filter with arguments valid for every input class."""
+    extra = {
+        'slice_implicit': dict(implicit_function=generate_plane((1.0, 0.0, 0.0), (0.0, 0.0, 0.0))),
+        'slice_along_line': dict(line=pv.Line((-2.0, -2.0, -2.0), (2.0, 2.0, 2.0), resolution=4)),
+    }.get(name, {})
+    return getattr(mesh, name)(**extra, **kwargs)
+
+
+def test_slice_composite_pointset_block_contour():
+    """A PointSet block gives the cutter an empty output with no arrays to contour."""
+    points = pv.PointSet(np.random.default_rng(0).uniform(-1, 1, (30, 3)))
+    points.point_data['data'] = np.arange(points.n_points, dtype=float)
+    image = pv.ImageData(dimensions=(5, 5, 5))
+    image.point_data['data'] = np.linspace(0.0, 1.0, image.n_points)
+    composite = pv.MultiBlock({'image': image, 'points': points})
+
+    sliced = composite.slice(generate_triangles=True, contour=True)
+
+    assert type(sliced['points']) is pv.PolyData
+    assert sliced['points'].is_empty
+
+
 def test_slice_generate_triangles_true_emits_only_triangles():
     grid = examples.load_uniform().cast_to_unstructured_grid()
     out = grid.slice(normal=(1, 1, 1), generate_triangles=True)

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -782,19 +782,54 @@ def test_slice_filter_composite(multiblock_all):
     assert output.n_blocks == multiblock_all.n_blocks
 
 
-def test_slice_filter_composite_pointset_block_is_empty(multiblock_all):
-    """``slice`` runs through :vtk:`vtkCutter`'s own composite dispatch.
+def _slice_call(mesh, name):
+    """Call one slice filter on a mesh with arguments that suit it."""
+    bounds = mesh.bounds
+    kwargs = {
+        'slice': dict(normal=normals[0]),
+        'slice_implicit': dict(implicit_function=generate_plane((1.0, 0.0, 0.0), mesh.center)),
+        'slice_along_line': dict(
+            line=pv.Line(
+                (bounds.x_min, bounds.y_min, bounds.z_min),
+                (bounds.x_max, bounds.y_max, bounds.z_max),
+                resolution=10,
+            )
+        ),
+        'slice_along_axis': dict(n=2),
+    }.get(name, {})
+    return getattr(mesh, name)(**kwargs)
 
-    Unlike ``slice_orthogonal``/``slice_along_axis`` (which iterate blocks in
-    Python and hit :class:`~pyvista.PointSet`'s ``PointSetDimensionReductionError``
-    guard directly), ``slice`` never calls into the Python-level override for a
-    ``PointSet`` block, so it does not raise. The block is silently empty instead.
-    """
+
+@pytest.mark.parametrize(
+    'name',
+    ['slice', 'slice_implicit', 'slice_along_line', 'slice_orthogonal', 'slice_along_axis'],
+)
+def test_slice_filter_composite_pointset_block_is_empty(multiblock_all, name):
+    """Every slice filter gives an empty block for a ``PointSet``, which has no cells."""
     pointset_index = next(
         i for i, block in enumerate(multiblock_all) if isinstance(block, pv.PointSet)
     )
-    output = multiblock_all.slice(normal=normals[0], progress_bar=True)
-    assert output[pointset_index].is_empty
+    pointset = multiblock_all[pointset_index]
+    pointset.field_data['meta'] = [1.0]
+
+    block = _slice_call(multiblock_all, name)[pointset_index]
+
+    blocks = block if isinstance(block, pv.MultiBlock) else [block]
+    for sliced in blocks:
+        assert isinstance(sliced, pv.PolyData)
+        assert sliced.is_empty
+        assert sliced.array_names == pointset.array_names
+        assert np.allclose(sliced.field_data['meta'], [1.0])
+
+
+@pytest.mark.parametrize(
+    'name',
+    ['slice', 'slice_implicit', 'slice_along_line', 'slice_orthogonal', 'slice_along_axis'],
+)
+def test_slice_filter_pointset_raises(pointset, name):
+    """A ``PointSet`` on its own still refuses to be sliced."""
+    with pytest.raises(pv.PointSetDimensionReductionError):
+        _slice_call(pointset, name)
 
 
 def test_slice_orthogonal_filter(datasets_no_pointset):
@@ -808,15 +843,10 @@ def test_slice_orthogonal_filter(datasets_no_pointset):
             assert isinstance(slc, pv.PolyData)
 
 
-def test_slice_orthogonal_filter_composite(multiblock_all_no_pointset):
+def test_slice_orthogonal_filter_composite(multiblock_all):
     # Now test composite data structures
-    output = multiblock_all_no_pointset.slice_orthogonal(progress_bar=True)
-    assert output.n_blocks == multiblock_all_no_pointset.n_blocks
-
-
-def test_slice_orthogonal_filter_composite_pointset_raises(multiblock_all):
-    with pytest.raises(pv.PointSetDimensionReductionError):
-        multiblock_all.slice_orthogonal(progress_bar=True)
+    output = multiblock_all.slice_orthogonal(progress_bar=True)
+    assert output.n_blocks == multiblock_all.n_blocks
 
 
 def test_slice_along_axis(datasets_no_pointset):
@@ -835,15 +865,10 @@ def test_slice_along_axis(datasets_no_pointset):
         dataset.slice_along_axis(axis='u')
 
 
-def test_slice_along_axis_composite(multiblock_all_no_pointset):
+def test_slice_along_axis_composite(multiblock_all):
     # Now test composite data structures
-    output = multiblock_all_no_pointset.slice_along_axis(progress_bar=True)
-    assert output.n_blocks == multiblock_all_no_pointset.n_blocks
-
-
-def test_slice_along_axis_composite_pointset_raises(multiblock_all):
-    with pytest.raises(pv.PointSetDimensionReductionError):
-        multiblock_all.slice_along_axis(progress_bar=True)
+    output = multiblock_all.slice_along_axis(progress_bar=True)
+    assert output.n_blocks == multiblock_all.n_blocks
 
 
 def test_extract_all_edges(datasets_no_pointset):
@@ -1208,25 +1233,11 @@ def test_slice_along_line_composite(multiblock_all):
         ('slice_along_axis', pv.MultiBlock),
     ],
 )
-def test_slice_composite_output_type(multiblock_all_no_pointset, call, block_type):
-    bounds = multiblock_all_no_pointset.bounds
-    kwargs = {
-        'slice_implicit': dict(
-            implicit_function=generate_plane((1.0, 0.0, 0.0), multiblock_all_no_pointset.center)
-        ),
-        'slice_along_line': dict(
-            line=pv.Line(
-                (bounds.x_min, bounds.y_min, bounds.z_min),
-                (bounds.x_max, bounds.y_max, bounds.z_max),
-                resolution=10,
-            )
-        ),
-    }.get(call, {})
-
-    output = getattr(multiblock_all_no_pointset, call)(**kwargs)
+def test_slice_composite_output_type(multiblock_all, call, block_type):
+    output = _slice_call(multiblock_all, call)
 
     assert isinstance(output, pv.MultiBlock)
-    assert output.n_blocks == multiblock_all_no_pointset.n_blocks
+    assert output.n_blocks == multiblock_all.n_blocks
     assert all(isinstance(block, block_type) for block in output)
 
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -317,6 +317,20 @@ def test_clip_box_no_unused_points(as_composite):
     assert np.allclose(clipped.bounds, new_bounds)
 
 
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_polydata_no_unused_points(invert):
+    mesh = pv.Sphere(theta_resolution=16, phi_resolution=16)
+    clipped = mesh.clip_box([0.1, 1.0, 0.1, 1.0, 0.1, 1.0], invert=invert)
+    assert clipped.n_points == len(np.unique(clipped.cell_connectivity))
+
+
+def test_clip_box_polydata_empty_output_has_no_points():
+    mesh = pv.Sphere(theta_resolution=16, phi_resolution=16)
+    clipped = mesh.clip_box([0.3, 1.0, 0.3, 1.0, 0.3, 1.0], invert=False)
+    assert clipped.n_cells == 0
+    assert clipped.n_points == 0
+
+
 def _box_clip_filter(mesh, bounds, *, invert):
     alg = _vtk.vtkBoxClipDataSet()
     alg.SetInputDataObject(mesh)

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -123,6 +123,36 @@ def test_clip_filter_pointset_no_points_removed(pointset, as_composite):
     assert n_points_in == n_points_out
 
 
+@pytest.mark.parametrize(
+    'mesh',
+    [
+        pv.Sphere(),
+        pv.PointSet(np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])),
+        pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid(),
+    ],
+    ids=['polydata', 'pointset', 'unstructured'],
+)
+def test_clip_inplace(mesh):
+    mesh = mesh.copy()
+    clipped = mesh.clip(inplace=True)
+    assert clipped is mesh
+
+
+@pytest.mark.parametrize(
+    'mesh',
+    [
+        pv.ImageData(dimensions=(5, 5, 5)),
+        pv.RectilinearGrid(*[np.linspace(-1, 1, 5)] * 3),
+        pv.MultiBlock([pv.Sphere()]),
+    ],
+    ids=['image', 'rectilinear', 'composite'],
+)
+def test_clip_inplace_raises(mesh):
+    match = f'Cannot use inplace=True for {type(mesh).__name__} input'
+    with pytest.raises(TypeError, match=match):
+        mesh.clip(inplace=True)
+
+
 def test_clip_filter_normal(datasets):
     # Test no errors are raised
     for i, dataset in enumerate(datasets):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1198,6 +1198,38 @@ def test_slice_along_line_composite(multiblock_all):
     assert output.n_blocks == multiblock_all.n_blocks
 
 
+@pytest.mark.parametrize(
+    ('call', 'block_type'),
+    [
+        ('slice', pv.PolyData),
+        ('slice_implicit', pv.PolyData),
+        ('slice_along_line', pv.PolyData),
+        ('slice_orthogonal', pv.MultiBlock),
+        ('slice_along_axis', pv.MultiBlock),
+    ],
+)
+def test_slice_composite_output_type(multiblock_all_no_pointset, call, block_type):
+    bounds = multiblock_all_no_pointset.bounds
+    kwargs = {
+        'slice_implicit': dict(
+            implicit_function=generate_plane((1.0, 0.0, 0.0), multiblock_all_no_pointset.center)
+        ),
+        'slice_along_line': dict(
+            line=pv.Line(
+                (bounds.x_min, bounds.y_min, bounds.z_min),
+                (bounds.x_max, bounds.y_max, bounds.z_max),
+                resolution=10,
+            )
+        ),
+    }.get(call, {})
+
+    output = getattr(multiblock_all_no_pointset, call)(**kwargs)
+
+    assert isinstance(output, pv.MultiBlock)
+    assert output.n_blocks == multiblock_all_no_pointset.n_blocks
+    assert all(isinstance(block, block_type) for block in output)
+
+
 def test_slice_generate_triangles_true_emits_only_triangles():
     grid = examples.load_uniform().cast_to_unstructured_grid()
     out = grid.slice(normal=(1, 1, 1), generate_triangles=True)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1358,6 +1358,14 @@ def test_cast_to_pointset(sphere):
     assert not np.allclose(sphere.active_scalars, pointset.active_scalars)
 
 
+@pytest.mark.parametrize('cast', ['cast_to_pointset', 'cast_to_poly_points'])
+def test_cast_to_points_keeps_field_data(sphere, cast):
+    sphere.field_data['meta'] = [1.0, 2.0]
+    points = getattr(sphere, cast)()
+    assert np.allclose(points.field_data['meta'], [1.0, 2.0])
+    assert not np.may_share_memory(sphere.field_data['meta'], points.field_data['meta'])
+
+
 def test_cast_to_pointset_cell_scalars(sphere):
     sphere.cell_data['cell_scalars'] = np.arange(sphere.n_cells)
     sphere.set_active_scalars('cell_scalars')

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -440,7 +440,8 @@ def test_clip_surface_output_type(datasets, crinkle):
 def test_clip_dataset_only_filters_are_not_composite(name):
     """These clips take a dataset, not a composite."""
     assert hasattr(pv.Sphere(), name)
-    assert not hasattr(pv.MultiBlock([pv.Sphere()]), name)
+    with pytest.raises(AttributeError, match=f"'MultiBlock' object has no attribute '{name}'"):
+        getattr(pv.MultiBlock([pv.Sphere()]), name)()
 
 
 def test_clip_closed_surface():

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -373,7 +373,7 @@ def test_clip_surface_compute_distance_does_not_modify_input(uniform):
 
 def test_clip_scalar_errors():
     mesh = pv.Wavelet()
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match='Cannot use inplace=True for ImageData input'):
         mesh.clip_scalar(value=(200, 300), inplace=True)
     with pytest.raises(ValueError, match='Cannot have invert=False for a range clip'):
         mesh.clip_scalar(value=(200, 300), invert=False)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -430,14 +430,17 @@ def test_clip_surface_output_type(datasets, crinkle):
         surface = pv.Sphere(radius=dataset.length, center=dataset.center)
         clp = dataset.clip_surface(surface, crinkle=crinkle)
         assert clp is not None
-        if isinstance(dataset, pv.PointSet):
-            assert isinstance(clp, pv.PointSet)
-        elif isinstance(dataset, pv.PolyData):
-            assert isinstance(clp, pv.PolyData)
-        elif isinstance(dataset, pv.MultiBlock):
-            assert isinstance(clp, pv.MultiBlock)
+        if isinstance(dataset, (pv.PointSet, pv.PolyData)):
+            assert type(clp) is type(dataset)
         else:
-            assert isinstance(clp, pv.UnstructuredGrid)
+            assert type(clp) is pv.UnstructuredGrid
+
+
+@pytest.mark.parametrize('name', ['clip_scalar', 'clip_surface', 'clip_closed_surface'])
+def test_clip_dataset_only_filters_are_not_composite(name):
+    """These clips take a dataset, not a composite."""
+    assert hasattr(pv.Sphere(), name)
+    assert not hasattr(pv.MultiBlock([pv.Sphere()]), name)
 
 
 def test_clip_closed_surface():

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -100,6 +100,8 @@ def test_cast_to_polydata(pointset, deep):
     assert isinstance(pdata, pv.PolyData)
     assert key in pdata.point_data
     assert np.allclose(pdata.field_data['meta'], [1.0, 2.0])
+    pdata.field_data['meta'][:] = 0
+    assert np.allclose(pointset.field_data['meta'], [1.0, 2.0] if deep else [0.0, 0.0])
     assert np.allclose(pdata.point_data[key], pointset.point_data[key])
     pdata.point_data[key][:] = 0
     if deep:

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -94,10 +94,12 @@ def test_cast_to_polydata(pointset, deep):
     data = np.linspace(0, 1, pointset.n_points)
     key = 'key'
     pointset.point_data[key] = data
+    pointset.field_data['meta'] = [1.0, 2.0]
 
     pdata = pointset.cast_to_polydata(deep=deep)
     assert isinstance(pdata, pv.PolyData)
     assert key in pdata.point_data
+    assert np.allclose(pdata.field_data['meta'], [1.0, 2.0])
     assert np.allclose(pdata.point_data[key], pointset.point_data[key])
     pdata.point_data[key][:] = 0
     if deep:


### PR DESCRIPTION
Running every clip and slice filter against every dataset class turned up eight behaviour bugs and a set of return types the docstrings got wrong. What each filter returns is now one rule — **a `PolyData` stays a `PolyData`, a `PointSet` stays a `PointSet`, every other dataset becomes an `UnstructuredGrid`, and a composite carries that rule into its blocks** — stated in the docstrings and held by a table of cases. One commit per issue.

Only the first is new: `ImageData.slice` lost the active vectors, normals, texture coordinates and tensors when #9074 gave axis-aligned planes their own code path. The rest predate it.

| Filter | Input | Was | Now |
| --- | --- | --- | --- |
| `slice` | `ImageData` with active vectors | active designations dropped | preserved, as with the cutter |
| `clip`, `clip_box`, `clip_slab` | `PointSet` | field data dropped | preserved |
| `clip_box` | `PointSet` | always empty | the points inside or outside the box |
| `clip_box` | `PolyData` | keeps points no cell references, sometimes points with no cells at all | unused points removed |
| `clip`, `clip_scalar` | grid classes, `MultiBlock` | opaque `copy_from` `TypeError`, or an `AttributeError` | `TypeError` naming the input class |
| `slice_orthogonal`, `slice_along_axis` | `MultiBlock` with a `PointSet` block | raised, where `slice` gave an empty block | empty block, like every other slice filter |
| `clip_box` | grid classes, `merge_points=False` | tetrahedra, from a different clipper | hexahedra, same cells as `merge_points=True` |
| `clip_box` | `PolyData` | `UnstructuredGrid`, alone among the clips | `PolyData`, same points and cells |

The last three change output, so this is a breaking change. `merge_points` now only decides whether coincident points are merged, which is what pyvista/pyvista#2168 asked for; it no longer selects `vtkBoxClipDataSet` and with it a different cell type. The five slice filters share one helper that slices a `PointSet` block as its vertices, so a composite no longer raises for a block a bare call would reject — a bare `PointSet.slice()` still raises.

Every `Returns` section now names the class per input class, says a composite carries the same rule into its blocks, and says what a `PointSet` block gets from a slice; `clip_scalar`, `clip_surface` and `clip_closed_surface` say they take a dataset and not a composite.

The perf work in #9073 and #9074 is unaffected, and the `merge_points` fix adds one gain. Best of 15 runs each, VTK 9.7, a 101³ image and a 90k-point sphere:

| | before #9073 | `main` | here |
| --- | --- | --- | --- |
| `clip_box` grid, `invert=True` | 2127 ms | 303 ms | 303 ms |
| `clip_box` grid, `invert=False` | 1285 ms | 120 ms | 120 ms |
| `clip_box` grid, `merge_points=False` | 2277 ms | 2279 ms | **266 ms** |
| `clip_box` `PolyData` | 142 ms | 142 ms | 143 ms |
| `slice` image, axis-aligned | 16.8 ms | 0.30 ms | 0.32 ms |
| `slice_orthogonal` image | 48.9 ms | 0.96 ms | 1.02 ms |
| `slice_along_axis` image, n=5 | 88.0 ms | 1.69 ms | 1.72 ms |
| `clip_surface` image | 6022 ms | 118 ms | 118 ms |

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
