### PR TITLE
Keep a failed accessor entry point pending and surface its cause

### DIFF
--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -153,12 +153,13 @@ safe (the second import is a no-op against ``sys.modules``).
 
 The lazy resolution means installing an accessor plugin does not
 affect ``import pyvista`` performance or stability. A broken plugin
-only surfaces when a user actually accesses its namespace: they get
-a ``UserWarning`` pointing at the specific plugin and an
-``AttributeError`` on the call, and no other code is affected.
+only surfaces when a user actually accesses its namespace: the first
+access emits a ``UserWarning`` pointing at the specific plugin, every
+access raises an ``AttributeError`` carrying the same message, the
+name drops out of ``dir(mesh)``, and no other code is affected.
 ``pv.registered_accessors()`` is the one call that explicitly forces
-discovery of every pending plugin so the returned list reflects the
-full picture.
+discovery of every pending plugin, retrying any that failed, so the
+returned list reflects the full picture.
 
 For production plugins on PyPI, prefer the entry-point path: users
 get zero-config discovery without any startup cost on ``import

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -28,6 +28,8 @@ pyvista.registered_accessors
 
 from __future__ import annotations
 
+import contextlib
+
 # ICN003 waived: tests patch this module-level name to intercept plugin
 # imports. Patching `importlib.import_module` instead would apply globally,
 # for every importer, for the duration of the test.
@@ -141,6 +143,9 @@ class _AccessorRegistryState(TypedDict):
     # and consumed by ``_resolve_pending_accessor`` on first attribute
     # miss.
     pending: dict[str, str]
+    # Pending names whose import failed, mapped to the failure message. Hidden
+    # from ``__dir__``; retried only by ``registered_accessors``.
+    failed: dict[str, str]
 
 
 # Cached-accessor bookkeeping lives in the instance dict under this prefix. It is
@@ -288,6 +293,7 @@ _registrations: list[AccessorRegistration] = []
 _prior_values: dict[tuple[type, str], Any] = {}
 _entry_points_loaded: bool = False
 _pending_accessors: dict[str, str] = {}
+_failed_accessors: dict[str, str] = {}
 
 
 def _save_registry_state() -> _AccessorRegistryState:
@@ -302,6 +308,7 @@ def _save_registry_state() -> _AccessorRegistryState:
         'attached': attached,
         'entry_points_loaded': _entry_points_loaded,
         'pending': dict(_pending_accessors),
+        'failed': dict(_failed_accessors),
     }
 
 
@@ -350,6 +357,8 @@ def _restore_registry_state(state: _AccessorRegistryState) -> None:
     _entry_points_loaded = state['entry_points_loaded']
     _pending_accessors.clear()
     _pending_accessors.update(state['pending'])
+    _failed_accessors.clear()
+    _failed_accessors.update(state['failed'])
 
 
 def _find_accessor_on_mro(target_cls: type, name: str) -> type | None:
@@ -693,24 +702,26 @@ def _resolve_pending_accessor(name: str) -> bool:
 
     Called from :meth:`pyvista.DataObject.__getattr__` when a normal
     attribute lookup misses. Ensures entry-point metadata has been
-    scanned, pops the pending entry for ``name``, and imports the
-    corresponding plugin module. Importing the module triggers any
-    ``@register_dataset_accessor`` decorators inside it and attaches
-    the accessor as a side effect.
+    scanned and imports the plugin module pending under ``name``.
+    Importing the module triggers any ``@register_dataset_accessor``
+    decorators inside it and attaches the accessor as a side effect;
+    only then is the entry removed from the pending list.
 
     Returns
     -------
     bool
         ``True`` if a plugin was loaded for ``name`` (and the attribute
         lookup should be retried). ``False`` if no pending plugin
-        matches ``name``, or if the plugin failed to import.
+        matches ``name``.
 
-    Notes
-    -----
-    A plugin that fails to import emits a ``UserWarning`` and is
-    dropped from the pending list, so subsequent lookups of the same
-    name fall straight through without re-triggering the import or
-    re-emitting the warning.
+    Raises
+    ------
+    AttributeError
+        If the plugin fails to import. The message names the entry
+        point, its module and the underlying error. The entry stays
+        pending but is marked failed: the first failure also emits a
+        ``UserWarning``, later accesses re-raise the recorded message
+        without re-importing, and :func:`registered_accessors` retries.
 
     """
     if name.startswith('_'):
@@ -718,18 +729,23 @@ def _resolve_pending_accessor(name: str) -> bool:
         # lookups can skip the entry-point scan entirely.
         return False
     _ensure_entry_points()
-    module_path = _pending_accessors.pop(name, None)
+    module_path = _pending_accessors.get(name)
     if module_path is None:
         return False
+    failure = _failed_accessors.get(name)
+    if failure is not None:
+        raise AttributeError(failure)
     try:
         import_module(module_path)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         msg = (
             f'Failed to load {ACCESSOR_ENTRY_POINT_GROUP} entry point '
             f'"{name}" from {module_path}: {exc}'
         )
+        _failed_accessors[name] = msg
         warn_external(msg)
-        return False
+        raise AttributeError(msg) from exc
+    del _pending_accessors[name]
     return True
 
 
@@ -740,10 +756,11 @@ def _pending_accessor_names() -> tuple[str, ...]:
     Jupyter / REPL tab completion surfaces accessors contributed by
     installed plugins even before those plugins have been imported. The
     plugin module itself is **not** loaded—only the entry-point
-    metadata is consulted.
+    metadata is consulted. Names whose plugin failed to import are
+    omitted until :func:`registered_accessors` imports them successfully.
     """
     _ensure_entry_points()
-    return tuple(_pending_accessors)
+    return tuple(name for name in _pending_accessors if name not in _failed_accessors)
 
 
 def registered_accessors() -> tuple[AccessorRegistration, ...]:
@@ -756,6 +773,11 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
     still appear in the result.
 
     .. versionadded:: 0.48.0
+
+    .. versionchanged:: 0.49.0
+        A plugin whose import failed stays pending and is retried on
+        every call, so an accessor whose dependency was installed after
+        the failure becomes available again.
 
     Returns
     -------
@@ -776,6 +798,8 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
 
     """
     _ensure_entry_points()
+    _failed_accessors.clear()
     for pending_name in list(_pending_accessors):
-        _resolve_pending_accessor(pending_name)
+        with contextlib.suppress(AttributeError):  # the failed import already warned
+            _resolve_pending_accessor(pending_name)
     return tuple(_registrations)

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -751,6 +751,7 @@ def _reset_entry_point_state(monkeypatch, eps: list):
     ``entry_points`` return value."""
     monkeypatch.setattr(_reg_mod, '_entry_points_loaded', False)
     _reg_mod._pending_accessors.clear()
+    _reg_mod._failed_accessors.clear()
     monkeypatch.setattr(
         'pyvista.core.utilities.accessor_registry.entry_points',
         lambda **_: eps,
@@ -930,41 +931,144 @@ def test_entry_point_metadata_scanned_once(monkeypatch):
     assert scan_count == 1
 
 
-def test_broken_plugin_warns_once_and_isolates(monkeypatch):
-    """A plugin that fails to import emits one ``UserWarning`` per
-    access attempt, does not crash pyvista, and does not affect
-    lookups of unrelated names."""
+def _broken_entry_point(monkeypatch, importer):
     ep = MagicMock()
     ep.name = 'broken'
     ep.value = 'broken_plugin_module'
-
     _reset_entry_point_state(monkeypatch, [ep])
-    monkeypatch.setattr(
-        'pyvista.core.utilities.accessor_registry.import_module',
-        MagicMock(side_effect=ImportError('missing dep')),
-    )
+    monkeypatch.setattr('pyvista.core.utilities.accessor_registry.import_module', importer)
 
-    # First access: warn and raise AttributeError because there is no
-    # accessor named 'broken' after the failed import.
+
+def _accessor_warnings(captured):
+    return [w for w in captured if 'accessor' in str(w.message)]
+
+
+@pytest.mark.parametrize('target', [pv.Sphere, pv.MultiBlock, lambda: pv.PolyData])
+def test_broken_plugin_warns_once_raises_with_cause_and_stays_pending(monkeypatch, target):
+    """A failed import warns on the first access only; every access raises
+    ``AttributeError`` naming the entry point, without re-importing, and
+    the entry stays pending."""
+    importer = MagicMock(side_effect=ImportError('missing dep'))
+    _broken_entry_point(monkeypatch, importer)
+    match = 'entry point "broken" from broken_plugin_module: missing dep'
+
+    with pytest.warns(UserWarning, match=match):
+        with pytest.raises(AttributeError, match=match) as excinfo:
+            _ = target().broken
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter('always')
+        for _ in range(3):
+            with pytest.raises(AttributeError, match=match):
+                _ = target().broken
+        assert not hasattr(target(), 'broken')
+    assert _accessor_warnings(captured) == []
+
+    assert importer.call_count == 1
+    assert _reg_mod._pending_accessors == {'broken': 'broken_plugin_module'}
+    assert list(_reg_mod._failed_accessors) == ['broken']
+    assert pv.Sphere().n_points > 0
+
+
+def test_plugin_that_registers_then_raises_is_not_re_executed(monkeypatch):
+    """Accessing a failed accessor never re-runs the plugin module, so an
+    accessor it attached before raising is neither re-registered nor
+    reported as a collision."""
+    body = (
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('sidecar', pv.PolyData)\n"
+        'class SidecarAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n'
+        "raise ImportError('missing dep')\n"
+    )
+    _broken_entry_point(monkeypatch, _fake_importer('broken_plugin_module', body))
+
+    try:
+        with pytest.warns(UserWarning, match='Failed to load'):
+            with pytest.raises(AttributeError):
+                _ = pv.Sphere().broken
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter('always')
+            for _ in range(3):
+                with pytest.raises(AttributeError, match='Failed to load'):
+                    _ = pv.Sphere().broken
+        assert _accessor_warnings(captured) == []
+        assert type(pv.Sphere().sidecar).__name__ == 'SidecarAccessor'
+    finally:
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('sidecar', pv.PolyData)
+        sys.modules.pop('broken_plugin_module', None)
+
+
+def test_broken_plugin_hidden_from_dir_until_import_succeeds(monkeypatch):
+    """``dir`` advertises a pending accessor until its import fails, then
+    hides it; ``registered_accessors()`` retries, and a successful import
+    attaches the accessor and lists it again."""
+    body = (
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('broken', pv.PolyData)\n"
+        'class BrokenAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n'
+    )
+    importer = MagicMock(side_effect=[ImportError('missing dep'), None])
+
+    def _import(module_path):
+        importer(module_path)
+        return _fake_importer(module_path, body)(module_path)
+
+    _broken_entry_point(monkeypatch, _import)
+
+    try:
+        assert 'broken' in dir(pv.Sphere())
+        assert 'broken' in _reg_mod._pending_accessor_names()
+        with pytest.warns(UserWarning, match='Failed to load'):
+            with pytest.raises(AttributeError, match='Failed to load'):
+                _ = pv.Sphere().broken
+        assert 'broken' not in dir(pv.Sphere())
+        assert 'broken' not in _reg_mod._pending_accessor_names()
+
+        assert 'broken' in {r.name for r in pv.registered_accessors()}
+        assert type(pv.Sphere().broken).__name__ == 'BrokenAccessor'
+        assert _reg_mod._pending_accessors == {}
+        assert _reg_mod._failed_accessors == {}
+        assert 'broken' in dir(pv.Sphere())
+        assert importer.call_count == 2
+    finally:
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('broken', pv.PolyData)
+        sys.modules.pop('broken_plugin_module', None)
+
+
+def test_registered_accessors_warns_and_retries_broken_plugin(monkeypatch):
+    """``registered_accessors()`` retries a failed plugin on every call,
+    warning each time it fails, and leaves the entry pending."""
+    importer = MagicMock(side_effect=ImportError('missing dep'))
+    _broken_entry_point(monkeypatch, importer)
+    match = 'entry point "broken" from broken_plugin_module'
+
+    for call in (1, 2):
+        with pytest.warns(UserWarning, match=match):
+            records = pv.registered_accessors()
+        assert isinstance(records, tuple)
+        assert importer.call_count == call
+    assert _reg_mod._pending_accessors == {'broken': 'broken_plugin_module'}
+    assert list(_reg_mod._failed_accessors) == ['broken']
+
+
+def test_save_restore_round_trip_preserves_failed(monkeypatch):
+    """Restoring a snapshot taken before a failed import forgets the failure."""
+    _broken_entry_point(monkeypatch, MagicMock(side_effect=ImportError('missing dep')))
+    state = _reg_mod._save_registry_state()
     with pytest.warns(UserWarning, match='Failed to load'):
         with pytest.raises(AttributeError):
             _ = pv.Sphere().broken
-
-    # Pending entry was consumed, so a second access is a clean
-    # AttributeError with no retry and no second "Failed to load"
-    # warning. Capture all warnings and assert specifically that no
-    # accessor-load warning fires; unrelated warnings (e.g. nightly
-    # NumPy / VTK deprecations) are ignored.
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter('always')
-        with pytest.raises(AttributeError):
-            _ = pv.Sphere().broken
-
-    accessor_warnings = [w for w in captured if 'Failed to load' in str(w.message)]
-    assert accessor_warnings == []
-
-    # Unrelated attributes still work.
-    assert pv.Sphere().n_points > 0
+    assert 'broken' in _reg_mod._failed_accessors
+    _reg_mod._restore_registry_state(state)
+    assert _reg_mod._failed_accessors == {}
+    assert 'broken' in _reg_mod._pending_accessor_names()
 
 
 def test_import_pyvista_does_not_import_plugin_modules(monkeypatch):


### PR DESCRIPTION
### Overview

`_resolve_pending_accessor` popped a `pyvista.accessors` entry point before importing its module and never put it back, so one failed import removed the accessor for the life of the process: the first access warned once, every later access was a bare `AttributeError`, and `dir(mesh)` kept advertising the name because `_pending_accessor_names` only reads metadata. Found downstream when a stale `dist-info` from a renamed package shadowed the live entry point and tab completion on the accessor silently came up empty, since IPython swallows the warning.

The entry now stays pending and the failure is recorded: access raises `AttributeError` carrying the entry-point name, module and underlying error (chained `from` it) without re-executing the plugin module, `dir()` drops the name while it is failing, and `pv.registered_accessors()` retries. Retrying on every attribute access was rejected because a plugin that registers an accessor and then raises would be re-executed each time and fire a collision warning per access.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
