### PR TITLE
Fix IPython tab completion on PyVista objects

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -284,6 +284,10 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
             raise TypeError(msg)
         return self.get_array(key)
 
+    def _ipython_key_completions_(self: Self) -> list[str]:
+        """Tab completion of IPython."""
+        return self.keys()
+
     def __setitem__(
         self: Self, key: str, value: ArrayLike[Any]
     ) -> None:  # numpydoc ignore=PR01,RT01

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -487,6 +487,22 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
         raise AttributeError(msg)
 
 
+def _allow_ipython_completion(cls: type) -> None:
+    """Let IPython's default completion policy evaluate instances of ``cls``.
+
+    IPython's ``limited`` evaluation policy refuses attribute and item access on
+    any class that overrides ``__getattribute__`` or ``__getattr__``, which every
+    VTK subclass does, unless the exact type is allow-listed. Tab completion such
+    as ``mesh.point_data['`` depends on that evaluation.
+    """
+    guarded_eval = sys.modules.get('IPython.core.guarded_eval')
+    policy = getattr(guarded_eval, 'EVALUATION_POLICIES', {}).get('limited')
+    for name in ('allowed_getattr', 'allowed_getitem'):
+        allowed = getattr(policy, name, None)
+        if isinstance(allowed, set):
+            allowed.add(cls)
+
+
 class _NoNewAttrMixin(metaclass=_AutoFreezeABCMeta):
     """``Mixin`` to prevent adding new attributes.
 
@@ -494,6 +510,11 @@ class _NoNewAttrMixin(metaclass=_AutoFreezeABCMeta):
     object. It freezes the attributes when called and prevents setting new ones via
     "normal" methods like ``obj.foo = 42``.
     """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Register each subclass with IPython's completion policy."""
+        super().__init_subclass__(**kwargs)
+        _allow_ipython_completion(cls)
 
     def _no_new_attributes(self, this_class: type) -> None:
         """Prevent setting additional attributes."""

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -495,7 +495,10 @@ def _allow_ipython_completion(cls: type) -> None:
     VTK subclass does, unless the exact type is allow-listed. Tab completion such
     as ``mesh.point_data['`` depends on that evaluation.
     """
-    guarded_eval = sys.modules.get('IPython.core.guarded_eval')
+    if 'IPython' not in sys.modules:
+        return
+    # IPython 9.17+ loads the completer lazily, so the module has to be imported here
+    guarded_eval = importlib.import_module('IPython.core.guarded_eval')
     policy = getattr(guarded_eval, 'EVALUATION_POLICIES', {}).get('limited')
     for name in ('allowed_getattr', 'allowed_getitem'):
         allowed = getattr(policy, name, None)

--- a/tests/core/test_ipython_completion.py
+++ b/tests/core/test_ipython_completion.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+from IPython.core.guarded_eval import EVALUATION_POLICIES
+from IPython.core.guarded_eval import EvaluationContext
+from IPython.core.guarded_eval import guarded_eval
+import numpy as np
+import pytest
+
+import pyvista as pv
+from pyvista.core.utilities.misc import _allow_ipython_completion
+
+LIMITED = EVALUATION_POLICIES['limited']
+
+
+class Mesh(pv.PolyData):
+    """Defined after IPython is imported, so class creation registers it."""
+
+
+class Blocks(pv.MultiBlock):
+    """Defined after IPython is imported, so class creation registers it."""
+
+
+@pytest.fixture
+def namespace():
+    # pytest imported pyvista before IPython, so register the classes created then
+    _allow_ipython_completion(pv.DataSetAttributes)
+    _allow_ipython_completion(pv.pyvista_ndarray)
+    mesh = Mesh(pv.Sphere())
+    mesh['scalars'] = np.arange(mesh.n_points)
+    return {'mesh': mesh, 'blocks': Blocks({'a': mesh})}
+
+
+@pytest.mark.parametrize('cls', [Mesh, Blocks])
+def test_subclass_registered(cls):
+    assert cls in LIMITED.allowed_getattr
+    assert cls in LIMITED.allowed_getitem
+
+
+def test_subclass_not_registered_without_ipython(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'IPython.core.guarded_eval')
+
+    class Unregistered(pv.PolyData): ...
+
+    assert Unregistered not in LIMITED.allowed_getattr
+    assert Unregistered not in LIMITED.allowed_getitem
+
+
+@pytest.mark.parametrize(
+    'expr',
+    [
+        'mesh.n_points',
+        'mesh.points.shape',
+        'mesh.point_data',
+        "mesh['scalars'].dtype",
+        "mesh.point_data['scalars'].shape",
+        "blocks['a'].active_scalars_name",
+        'blocks[0].n_points',
+    ],
+)
+def test_guarded_eval_limited(namespace, expr):
+    context = EvaluationContext(globals={}, locals=namespace, evaluation='limited')
+    assert guarded_eval(expr, context) == eval(expr, {}, namespace)  # noqa: S307
+
+
+def test_dataset_attributes_key_completions(namespace):
+    point_data = namespace['mesh'].point_data
+    assert point_data._ipython_key_completions_() == ['Normals', 'scalars']
+
+
+def test_ipython_completer(tmp_path):
+    code = textwrap.dedent(
+        """
+        import IPython
+        import numpy as np
+        import pyvista as pv
+        import pyvista.plotting
+        from IPython.core.completer import provisionalcompleter
+        from IPython.core.guarded_eval import EVALUATION_POLICIES
+        from IPython.core.interactiveshell import InteractiveShell
+        from pyvista.core.utilities.misc import _NoNewAttrMixin
+
+        def subclasses(cls):
+            for sub in cls.__subclasses__():
+                yield sub
+                yield from subclasses(sub)
+
+        allowed = EVALUATION_POLICIES['limited'].allowed_getattr
+        missing = {cls for cls in subclasses(_NoNewAttrMixin) if cls not in allowed}
+        assert not missing, missing
+
+        ip = InteractiveShell.instance()
+        mesh = pv.Sphere()
+        mesh['scalars'] = np.arange(mesh.n_points)
+        ip.user_ns['mesh'] = mesh
+
+        def complete(text):
+            with provisionalcompleter():
+                completions = ip.Completer.completions(text, len(text))
+                return {c.text.lstrip('.') for c in completions}
+
+        assert 'scalars' in complete("mesh.point_data['")
+        ip.Completer.use_jedi = False
+        assert 'scalars' in complete("mesh.point_data['")
+        assert 'active_scalars' in complete('mesh.point_data.act')
+        assert 'shape' in complete("mesh.point_data['scalars'].sh")
+        """
+    )
+    env = {**os.environ, 'IPYTHONDIR': str(tmp_path)}
+    subprocess.run([sys.executable, '-c', code], check=True, env=env)

--- a/tests/core/test_ipython_completion.py
+++ b/tests/core/test_ipython_completion.py
@@ -42,7 +42,7 @@ def test_subclass_registered(cls):
 
 
 def test_subclass_not_registered_without_ipython(monkeypatch):
-    monkeypatch.delitem(sys.modules, 'IPython.core.guarded_eval')
+    monkeypatch.delitem(sys.modules, 'IPython')
 
     class Unregistered(pv.PolyData): ...
 


### PR DESCRIPTION
### Overview

IPython's default completion policy (`IPCompleter.evaluation = 'limited'`) refuses to evaluate attribute or item access on any class that overrides `__getattribute__` or `__getattr__` unless the exact type is on its allow-list, and every VTK subclass overrides it. So `mesh.point_data['<TAB>` has never offered array names in IPython or Jupyter, even with jedi on: dict-key completion is IPython's own and goes through that policy, and `point_data` is a property, which the policy permits only on allow-listed types. With `use_jedi = False`, every attribute chain on a PyVista object completes nothing.

`_NoNewAttrMixin.__init_subclass__` now registers each PyVista class, and any subclass a user or plugin defines later, with the limited policy whenever IPython is already imported, following [mikeio1d](https://github.com/DHI/mikeio1d/blob/main/src/mikeio1d/various.py). `DataSetAttributes` gains `_ipython_key_completions_` so the key completer has keys to offer. Registration is exact-type only: the module-path allow-list entries exist only in IPython 9 and raise `TypeError` in 8.x.

Changes drafted by Claude Fable 5.1 but fully understood by me.
