### PR TITLE
Fix and speed up Transform and the transform filter

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -145,8 +145,8 @@ def _convert_transform_input_to_float(
 
 def _copy_transformed_arrays(output: DataSet, filtered: DataObject, *, copy: bool) -> None:
     """Copy the point, cell and field arrays the transform filter produced."""
-    output.point_data.update(filtered.point_data, copy=copy)  # type: ignore[attr-defined]
-    output.cell_data.update(filtered.cell_data, copy=copy)  # type: ignore[attr-defined]
+    output.point_data.update(filtered.point_data, copy=copy)
+    output.cell_data.update(filtered.cell_data, copy=copy)
     output.field_data.update(filtered.field_data, copy=copy)
 
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -14,6 +14,7 @@ import itertools
 import re
 import reprlib
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Generic
 from typing import Literal
 from typing import NamedTuple
@@ -53,11 +54,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import ClassVar
 
+    from pyvista import DataObject
     from pyvista import DataSet
     from pyvista import DataSetAttributes
     from pyvista import ImageData
     from pyvista import MultiBlock
     from pyvista import PolyData
+    from pyvista import RectilinearGrid
     from pyvista import RotationLike
     from pyvista import TransformLike
     from pyvista import VectorLike
@@ -96,6 +99,76 @@ def _rectilinear_transform_components(
 
     # Lump the scale, the reflection, and any reflection from the rotation together
     return T, S * N * np.diagonal(R)
+
+
+def _transform_vector_names(
+    point_data: DataSetAttributes,
+    cell_data: DataSetAttributes,
+    shape: tuple[int, int],
+    *,
+    all_vectors: bool,
+) -> tuple[list[str | None], list[str | None]]:
+    """Return the point and cell array names which the transform filter treats as vectors."""
+    if all_vectors:
+        n_points, n_cells = shape
+        return (
+            [name for name, data in point_data.items() if data.shape == (n_points, 3)],
+            [name for name, data in cell_data.items() if data.shape == (n_cells, 3)],
+        )
+    return (
+        [point_data.active_vectors_name, point_data.active_normals_name],
+        [cell_data.active_vectors_name, cell_data.active_normals_name],
+    )
+
+
+def _convert_transform_input_to_float(
+    dataset: DataSet,
+    vectors: Sequence[tuple[DataSetAttributes, list[str | None]]],
+    dtype: np.dtype[Any],
+) -> bool:
+    """Convert a dataset's integer points and named vector arrays to float, in place."""
+    converted = False
+    points = dataset.points
+    if not np.issubdtype(points.dtype, np.floating):
+        dataset.points = points.astype(dtype)
+        converted = True
+    for attributes, names in vectors:
+        for name in names:
+            if name is None:
+                continue
+            array = attributes[name]
+            if not np.issubdtype(array.dtype, np.floating):
+                attributes[name] = array.astype(dtype)
+                converted = True
+    return converted
+
+
+def _copy_transformed_arrays(output: DataSet, filtered: DataObject, *, copy: bool) -> None:
+    """Copy the point, cell and field arrays the transform filter produced."""
+    output.point_data.update(filtered.point_data, copy=copy)  # type: ignore[attr-defined]
+    output.cell_data.update(filtered.cell_data, copy=copy)  # type: ignore[attr-defined]
+    output.field_data.update(filtered.field_data, copy=copy)
+
+
+def _orient_image_structure(output: ImageData, dataset: ImageData, transform: Transform) -> None:
+    """Give an image the structure of another, oriented by a transformation."""
+    # vtkTransformFilter returns a StructuredGrid, so the structure is transformed here
+    output.copy_structure(dataset)
+    matrix = Transform(output.index_to_physical_matrix).compose(transform).matrix
+    output.index_to_physical_matrix = matrix
+
+
+def _transform_rectilinear_axes(
+    output: RectilinearGrid,
+    dataset: RectilinearGrid,
+    components: tuple[NumpyArray[float], NumpyArray[float]],
+) -> None:
+    """Set a grid's axes to another's, scaled and translated."""
+    # vtkTransformFilter returns a StructuredGrid, so the axes are transformed here instead
+    translation, scale = components
+    output.x = dataset.x * scale[0] + translation[0]
+    output.y = dataset.y * scale[1] + translation[1]
+    output.z = dataset.z * scale[2] + translation[2]
 
 
 class _CellStatusTuple(NamedTuple):
@@ -2032,44 +2105,23 @@ class DataObjectFilters:
             _rectilinear_transform_components(t) if isinstance(self, pv.RectilinearGrid) else None
         )
 
-        # vtkTransformFilter truncates the result if the input is an integer type
-        # so convert input points and relevant vectors to float
-        # (creating a new copy would be harmful much more often)
-        float_dtype = _points_dtype() or np.dtype(np.float32)
-        converted_ints = False
-        points = self.points
-        if not np.issubdtype(points.dtype, np.floating):
-            self.points = points.astype(float_dtype)
-            converted_ints = True
         # Optimization: build the attribute wrappers once; they refer to the same VTK objects
         # for the whole filter, including after copy_from, so reusing them is safe
         point_data = self.point_data
         cell_data = self.cell_data
-        if transform_all_input_vectors:
-            # all vector-shaped data will be transformed
-            n_points, n_cells = self.n_points, self.n_cells
-            point_vectors: list[str | None] = [
-                name for name, data in point_data.items() if data.shape == (n_points, 3)
-            ]
-            cell_vectors: list[str | None] = [
-                name for name, data in cell_data.items() if data.shape == (n_cells, 3)
-            ]
-        else:
-            # we'll only transform active vectors and normals
-            point_vectors = [point_data.active_vectors_name, point_data.active_normals_name]
-            cell_vectors = [cell_data.active_vectors_name, cell_data.active_normals_name]
-        # dynamically convert each self.point_data[name] etc. to the configured float
-        all_vectors = [point_vectors, cell_vectors]
-        all_dataset_attrs = [point_data, cell_data]
-        for vector_names, dataset_attrs in zip(all_vectors, all_dataset_attrs, strict=True):
-            for vector_name in vector_names:
-                if vector_name is None:
-                    continue
-                vector_arr = dataset_attrs[vector_name]
-                if not np.issubdtype(vector_arr.dtype, np.floating):
-                    dataset_attrs[vector_name] = vector_arr.astype(float_dtype)
-                    converted_ints = True
-        if converted_ints:
+        point_vectors, cell_vectors = _transform_vector_names(
+            point_data,
+            cell_data,
+            (self.n_points, self.n_cells),
+            all_vectors=transform_all_input_vectors,
+        )
+
+        # vtkTransformFilter truncates the result if the input is an integer type, so convert
+        # this mesh in place (creating a new copy would be harmful much more often)
+        float_dtype = _points_dtype() or np.dtype(np.float32)
+        if _convert_transform_input_to_float(
+            self, [(point_data, point_vectors), (cell_data, cell_vectors)], float_dtype
+        ):
             warn_external(
                 'Integer points, vector, and normal data (if any) of the input mesh '
                 f'have been converted to ``np.{float_dtype.name}``. '
@@ -2096,44 +2148,19 @@ class DataObjectFilters:
             vtk_filter_output = _get_output(f)
 
             if isinstance(output, pv.ImageData):
-                # vtkTransformFilter returns a StructuredGrid for legacy code (before VTK 9)
-                # but VTK 9+ supports oriented images.
-                # To keep an ImageData -> ImageData mapping, we copy the transformed data
-                # from the filter output but manually transform the structure
-                output.copy_structure(self)  # type: ignore[arg-type]
-                current_matrix = output.index_to_physical_matrix
-                new_matrix = pv.Transform(current_matrix).compose(t).matrix
-                output.index_to_physical_matrix = new_matrix
-
-                output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
-                output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
-                output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
-
+                _orient_image_structure(output, cast('pv.ImageData', self), t)
+                _copy_transformed_arrays(output, vtk_filter_output, copy=not inplace)
             elif isinstance(output, pv.RectilinearGrid):
-                # Transform the axes directly, since vtkTransformFilter returns a StructuredGrid
-                translation, scale = cast(
-                    'tuple[NumpyArray[float], NumpyArray[float]]', rectilinear_components
+                _transform_rectilinear_axes(
+                    output,
+                    cast('pv.RectilinearGrid', self),
+                    cast('tuple[NumpyArray[float], NumpyArray[float]]', rectilinear_components),
                 )
-
-                # Apply transformation to structure
-                tx, ty, tz = translation
-                sx, sy, sz = scale
-                output.x = self.x * sx + tx
-                output.y = self.y * sy + ty
-                output.z = self.z * sz + tz
-
-                # Copy data arrays from the vtkTransformFilter's output
-                output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
-                output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
-                output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
-
-            elif inplace:
-                output.copy_from(vtk_filter_output, deep=False)
+                _copy_transformed_arrays(output, vtk_filter_output, copy=not inplace)
             else:
-                # The output from the transform filter contains a shallow copy
-                # of the original dataset except for the point arrays.  Here
-                # we perform a copy so the two are completely unlinked.
-                output.copy_from(vtk_filter_output, deep=True)
+                # A shallow copy leaves the output sharing everything but the points with
+                # the filter's own output, which is only safe when transforming in place
+                output.copy_from(vtk_filter_output, deep=not inplace)
 
             # Make the previously active scalars of the output active again
             if output is not self:

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -71,6 +71,33 @@ if TYPE_CHECKING:
     _T = TypeVar('_T')
 
 
+def _rectilinear_transform_components(
+    transform: Transform,
+) -> tuple[NumpyArray[float], NumpyArray[float]]:
+    """Return the translation and scale of a transform a rectilinear grid can represent."""
+    # Follow similar decomposition performed by ImageData.index_to_physical_matrix
+    T, R, N, S, K = transform.decompose()
+
+    if not np.allclose(K, np.eye(3)):
+        msg = (
+            'The transformation has a shear component which is not supported by '
+            'RectilinearGrid.\nCast to StructuredGrid first to support shear '
+            'transformations, or use `Transform.decompose()`\nto remove this component.'
+        )
+        raise ValueError(msg)
+
+    if not np.allclose(np.abs(R), np.eye(3)):
+        msg = (
+            'The transformation has a non-diagonal rotation component which is not '
+            'supported by\nRectilinearGrid. Cast to StructuredGrid first to fully '
+            'support rotations, or use\n`Transform.decompose()` to remove this component.'
+        )
+        raise ValueError(msg)
+
+    # Lump the scale, the reflection, and any reflection from the rotation together
+    return T, S * N * np.diagonal(R)
+
+
 class _CellStatusTuple(NamedTuple):
     """Value and documentation of a cell status flag."""
 
@@ -2000,6 +2027,11 @@ class DataObjectFilters:
             msg = 'Transform element (3,3), the inverse scale term, is zero'
             raise ValueError(msg)
 
+        # Validate before this mesh is modified below
+        rectilinear_components = (
+            _rectilinear_transform_components(t) if isinstance(self, pv.RectilinearGrid) else None
+        )
+
         # vtkTransformFilter truncates the result if the input is an integer type
         # so convert input points and relevant vectors to float
         # (creating a new copy would be harmful much more often)
@@ -2077,34 +2109,13 @@ class DataObjectFilters:
             output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
 
         elif isinstance(output, pv.RectilinearGrid):
-            # vtkTransformFilter returns a StructuredGrid, but we can return
-            # RectilinearGrid if we ignore shear and rotations
-            # Follow similar decomposition performed by ImageData.index_to_physical_matrix
-            T, R, N, S, K = t.decompose()
-
-            if not np.allclose(K, np.eye(3)):
-                msg = (
-                    'The transformation has a shear component which is not supported by '
-                    'RectilinearGrid.\nCast to StructuredGrid first to support shear '
-                    'transformations, or use `Transform.decompose()`\nto remove this component.'
-                )
-                raise ValueError(msg)
-
-            # Lump scale and reflection together
-            scale = S * N
-            if not np.allclose(np.abs(R), np.eye(3)):
-                msg = (
-                    'The transformation has a non-diagonal rotation component which is not '
-                    'supported by\nRectilinearGrid. Cast to StructuredGrid first to fully '
-                    'support rotations, or use\n`Transform.decompose()` to remove this component.'
-                )
-                raise ValueError(msg)
-            else:
-                # Lump any reflections from the rotation into the scale
-                scale *= np.diagonal(R)
+            # Transform the axes directly, since vtkTransformFilter returns a StructuredGrid
+            translation, scale = cast(
+                'tuple[NumpyArray[float], NumpyArray[float]]', rectilinear_components
+            )
 
             # Apply transformation to structure
-            tx, ty, tz = T
+            tx, ty, tz = translation
             sx, sy, sz = scale
             output.x = self.x * sx + tx
             output.y = self.y * sy + ty

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2080,67 +2080,69 @@ class DataObjectFilters:
         active_point_scalars_name: str | None = point_data.active_scalars_name
         active_cell_scalars_name: str | None = cell_data.active_scalars_name
 
+        output = self if inplace else self.__class__()
+
         # vtkTransformFilter sometimes doesn't transform all vector arrays
         # when there are active point/cell scalars. Use this workaround
         self.active_scalars_name = None
 
-        f = _vtk.vtkTransformFilter()
-        f.SetInputDataObject(self)
-        f.SetTransform(t)
-        f.SetTransformAllInputVectors(transform_all_input_vectors)
+        try:
+            f = _vtk.vtkTransformFilter()
+            f.SetInputDataObject(self)
+            f.SetTransform(t)
+            f.SetTransformAllInputVectors(transform_all_input_vectors)
 
-        _update_alg(f, progress_bar=progress_bar, message='Transforming')
-        vtk_filter_output = _get_output(f)
+            _update_alg(f, progress_bar=progress_bar, message='Transforming')
+            vtk_filter_output = _get_output(f)
 
-        output = self if inplace else self.__class__()
+            if isinstance(output, pv.ImageData):
+                # vtkTransformFilter returns a StructuredGrid for legacy code (before VTK 9)
+                # but VTK 9+ supports oriented images.
+                # To keep an ImageData -> ImageData mapping, we copy the transformed data
+                # from the filter output but manually transform the structure
+                output.copy_structure(self)  # type: ignore[arg-type]
+                current_matrix = output.index_to_physical_matrix
+                new_matrix = pv.Transform(current_matrix).compose(t).matrix
+                output.index_to_physical_matrix = new_matrix
 
-        if isinstance(output, pv.ImageData):
-            # vtkTransformFilter returns a StructuredGrid for legacy code (before VTK 9)
-            # but VTK 9+ supports oriented images.
-            # To keep an ImageData -> ImageData mapping, we copy the transformed data
-            # from the filter output but manually transform the structure
-            output.copy_structure(self)  # type: ignore[arg-type]
-            current_matrix = output.index_to_physical_matrix
-            new_matrix = pv.Transform(current_matrix).compose(t).matrix
-            output.index_to_physical_matrix = new_matrix
+                output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
+                output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
+                output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
 
-            output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
-            output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
-            output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
+            elif isinstance(output, pv.RectilinearGrid):
+                # Transform the axes directly, since vtkTransformFilter returns a StructuredGrid
+                translation, scale = cast(
+                    'tuple[NumpyArray[float], NumpyArray[float]]', rectilinear_components
+                )
 
-        elif isinstance(output, pv.RectilinearGrid):
-            # Transform the axes directly, since vtkTransformFilter returns a StructuredGrid
-            translation, scale = cast(
-                'tuple[NumpyArray[float], NumpyArray[float]]', rectilinear_components
-            )
+                # Apply transformation to structure
+                tx, ty, tz = translation
+                sx, sy, sz = scale
+                output.x = self.x * sx + tx
+                output.y = self.y * sy + ty
+                output.z = self.z * sz + tz
 
-            # Apply transformation to structure
-            tx, ty, tz = translation
-            sx, sy, sz = scale
-            output.x = self.x * sx + tx
-            output.y = self.y * sy + ty
-            output.z = self.z * sz + tz
+                # Copy data arrays from the vtkTransformFilter's output
+                output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
+                output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
+                output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
 
-            # Copy data arrays from the vtkTransformFilter's output
-            output.point_data.update(vtk_filter_output.point_data, copy=not inplace)
-            output.cell_data.update(vtk_filter_output.cell_data, copy=not inplace)
-            output.field_data.update(vtk_filter_output.field_data, copy=not inplace)
+            elif inplace:
+                output.copy_from(vtk_filter_output, deep=False)
+            else:
+                # The output from the transform filter contains a shallow copy
+                # of the original dataset except for the point arrays.  Here
+                # we perform a copy so the two are completely unlinked.
+                output.copy_from(vtk_filter_output, deep=True)
 
-        elif inplace:
-            output.copy_from(vtk_filter_output, deep=False)
-        else:
-            # The output from the transform filter contains a shallow copy
-            # of the original dataset except for the point arrays.  Here
-            # we perform a copy so the two are completely unlinked.
-            output.copy_from(vtk_filter_output, deep=True)
-
-        # Make the previously active scalars active again
-        point_data.active_scalars_name = active_point_scalars_name
-        if output is not self:
-            output.point_data.active_scalars_name = active_point_scalars_name
-        cell_data.active_scalars_name = active_cell_scalars_name
-        if output is not self:
-            output.cell_data.active_scalars_name = active_cell_scalars_name
+            # Make the previously active scalars of the output active again
+            if output is not self:
+                output.point_data.active_scalars_name = active_point_scalars_name
+                output.cell_data.active_scalars_name = active_cell_scalars_name
+        finally:
+            # Make the previously active scalars of this mesh active again
+            point_data.active_scalars_name = active_point_scalars_name
+            cell_data.active_scalars_name = active_cell_scalars_name
 
         return output
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2139,13 +2139,13 @@ class DataObjectFilters:
         self.active_scalars_name = None
 
         try:
-            f = _vtk.vtkTransformFilter()
-            f.SetInputDataObject(self)
-            f.SetTransform(t)
-            f.SetTransformAllInputVectors(transform_all_input_vectors)
+            alg = _vtk.vtkTransformFilter()
+            alg.SetInputDataObject(self)
+            alg.SetTransform(t)
+            alg.SetTransformAllInputVectors(transform_all_input_vectors)
 
-            _update_alg(f, progress_bar=progress_bar, message='Transforming')
-            vtk_filter_output = _get_output(f)
+            _update_alg(alg, progress_bar=progress_bar, message='Transforming')
+            vtk_filter_output = _get_output(alg)
 
             if isinstance(output, pv.ImageData):
                 _orient_image_structure(output, cast('pv.ImageData', self), t)

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -2383,12 +2383,12 @@ class Transform(
         translate_before, translate_after = self._get_point_translations(
             point=point, multiply_mode=multiply_mode
         )
-        if translate_before:
+        if translate_before is not None:
             self._compose(translate_before, multiply_mode=multiply_mode)
 
         self._compose(transform, multiply_mode=multiply_mode)
 
-        if translate_after:
+        if translate_after is not None:
             self._compose(translate_after, multiply_mode=multiply_mode)
 
         return self
@@ -2397,12 +2397,15 @@ class Transform(
         self: Transform,
         point: VectorLike[float] | None,
         multiply_mode: Literal['pre', 'post'] | None,
-    ) -> tuple[Transform | None, Transform | None]:
+    ) -> tuple[_vtk.vtkTransform | None, _vtk.vtkTransform | None]:
         point = point if point is not None else self.point
         if point is not None:
             point_array = _validation.validate_array3(point, dtype_out=float, name='point')
-            translate_away = Transform().translate(-point_array)
-            translate_toward = Transform().translate(point_array)
+            # Optimization: plain VTK transforms, which are composed as they are
+            translate_away = _vtk.vtkTransform()
+            translate_away.Translate(*(-point_array))
+            translate_toward = _vtk.vtkTransform()
+            translate_toward.Translate(*point_array)
             if multiply_mode == 'post' or (
                 multiply_mode is None and self._multiply_mode == 'post'
             ):

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -285,7 +285,7 @@ class Transform(
     def __add__(self: Transform, other: VectorLike[float]) -> Transform:
         """:meth:`translate` this transform using post-multiply semantics."""
         try:
-            return self.copy().translate(other, multiply_mode='post')
+            return self._copy_about_origin().translate(other, multiply_mode='post')
         except TypeError:
             msg = (
                 f"Unsupported operand type(s) for +: '{self.__class__.__name__}' "
@@ -304,7 +304,7 @@ class Transform(
     def __radd__(self: Transform, other: VectorLike[float]) -> Transform:
         """:meth:`translate` this transform using pre-multiply semantics."""
         try:
-            return self.copy().translate(other, multiply_mode='pre')
+            return self._copy_about_origin().translate(other, multiply_mode='pre')
         except TypeError:
             msg = (
                 f"Unsupported operand type(s) for +: '{type(other).__name__}' "
@@ -327,8 +327,7 @@ class Transform(
         :meth:`compose` otherwise for transform-like inputs. The operation is applied
         about the origin, not about this transform's :attr:`point`.
         """
-        copied = self.copy()
-        copied.point = None
+        copied = self._copy_about_origin()
         try:
             transform = copied.scale(other, multiply_mode='post')  # type: ignore[arg-type]
         except (ValueError, TypeError):
@@ -352,9 +351,13 @@ class Transform(
         return transform
 
     def __rmul__(self: Transform, other: float | VectorLike[float]) -> Transform:
-        """:meth:`scale` this transform using pre-multiply semantics."""
+        """:meth:`scale` this transform using pre-multiply semantics.
+
+        The operation is applied about the origin, not about this transform's
+        :attr:`point`.
+        """
         try:
-            return self.copy().scale(other, multiply_mode='pre')
+            return self._copy_about_origin().scale(other, multiply_mode='pre')
         except TypeError:
             msg = (
                 f"Unsupported operand type(s) for *: '{type(other).__name__}' "
@@ -369,6 +372,12 @@ class Transform(
                 f'The left-side argument must be a single number or a length-3 vector.'
             )
             raise ValueError(msg)
+
+    def _copy_about_origin(self: Transform) -> Transform:
+        """Return a copy which composes about the origin instead of the point."""
+        copied = self.copy()
+        copied.point = None
+        return copied
 
     def copy(self: Transform) -> Transform:
         """Return a deep copy of the transform.
@@ -2401,7 +2410,7 @@ class Transform(
         point = point if point is not None else self.point
         if point is not None:
             point_array = _validation.validate_array3(point, dtype_out=float, name='point')
-            # Optimization: plain VTK transforms, which are composed as they are
+            # Optimization: a plain vtkTransform is what _compose concatenates anyway
             translate_away = _vtk.vtkTransform()
             translate_away.Translate(*(-point_array))
             translate_toward = _vtk.vtkTransform()

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -324,9 +324,11 @@ class Transform(
         """:meth:`compose` this transform using post-multiply semantics.
 
         Use :meth:`scale` for single numbers and length-3 vector inputs, and
-        :meth:`compose` otherwise for transform-like inputs.
+        :meth:`compose` otherwise for transform-like inputs. The operation is applied
+        about the origin, not about this transform's :attr:`point`.
         """
         copied = self.copy()
+        copied.point = None
         try:
             transform = copied.scale(other, multiply_mode='post')  # type: ignore[arg-type]
         except (ValueError, TypeError):
@@ -406,6 +408,8 @@ class Transform(
 
         # Need to copy other props not stored by vtkTransform
         new_transform.multiply_mode = self.multiply_mode
+        new_transform.point = self.point
+        new_transform.check_finite = self.check_finite
 
         return new_transform
 

--- a/pyvista/core/utilities/transformations.py
+++ b/pyvista/core/utilities/transformations.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
         NumpyArray[float],
     ]
 
-# Optimization: the default tolerances of `numpy.isclose`, applied here without its cost
+# The default tolerances of `numpy.isclose`
 _ATOL = 1e-8
 _RTOL = 1e-5
 
@@ -137,7 +137,7 @@ def axis_angle_rotation(  # noqa: PLR0917
     if axis_norm <= _ATOL:
         msg = 'Cannot rotate around zero vector axis.'
         raise ValueError(msg)
-    if abs(axis_norm - 1.0) > _ATOL + _RTOL:
+    if not abs(axis_norm - 1.0) <= _ATOL + _RTOL:
         axis_ = axis_ / axis_norm
 
     # build Rodrigues' rotation matrix
@@ -258,7 +258,7 @@ def reflection(
     if normal_norm <= _ATOL:
         msg = 'Plane normal cannot be zero.'
         raise ValueError(msg)
-    if abs(normal_norm - 1.0) > _ATOL + _RTOL:
+    if not abs(normal_norm - 1.0) <= _ATOL + _RTOL:
         normal = normal / normal_norm
 
     # build reflection matrix

--- a/pyvista/core/utilities/transformations.py
+++ b/pyvista/core/utilities/transformations.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
         NumpyArray[float],
     ]
 
+# Optimization: the default tolerances of `numpy.isclose`, applied here without its cost
+_ATOL = 1e-8
+_RTOL = 1e-5
+
 
 @_deprecate_positional_args(allowed=['axis', 'angle'])
 def axis_angle_rotation(  # noqa: PLR0917
@@ -130,10 +134,10 @@ def axis_angle_rotation(  # noqa: PLR0917
 
     # check and normalize
     axis_norm = np.linalg.norm(axis_)
-    if np.isclose(axis_norm, 0):
+    if axis_norm <= _ATOL:
         msg = 'Cannot rotate around zero vector axis.'
         raise ValueError(msg)
-    if not np.isclose(axis_norm, 1):
+    if abs(axis_norm - 1.0) > _ATOL + _RTOL:
         axis_ = axis_ / axis_norm
 
     # build Rodrigues' rotation matrix
@@ -251,10 +255,10 @@ def reflection(
 
     # check and normalize
     normal_norm = np.linalg.norm(normal)
-    if np.isclose(normal_norm, 0):
+    if normal_norm <= _ATOL:
         msg = 'Plane normal cannot be zero.'
         raise ValueError(msg)
-    if not np.isclose(normal_norm, 1):
+    if abs(normal_norm - 1.0) > _ATOL + _RTOL:
         normal = normal / normal_norm
 
     # build reflection matrix

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1422,6 +1422,19 @@ def test_transform_rectilinear_raises(rectilinear):
         rectilinear.transform(matrix, inplace=False)
 
 
+def test_transform_rectilinear_raises_leaves_input_unchanged(rectilinear):
+    rectilinear['a'] = np.arange(rectilinear.n_points, dtype=float)
+    rectilinear['b'] = np.arange(rectilinear.n_points, dtype=float)
+    rectilinear.set_active_scalars('a')
+    before = rectilinear.copy()
+
+    with pytest.raises(ValueError, match='non-diagonal rotation component'):
+        rectilinear.transform(pv.Transform().rotate_x(30), inplace=False)
+
+    assert rectilinear.active_scalars_name == 'a'
+    assert rectilinear == before
+
+
 def test_transform_rectilinear(rectilinear):
     # Test that various transformations applied sequentially work
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1422,17 +1422,33 @@ def test_transform_rectilinear_raises(rectilinear):
         rectilinear.transform(matrix, inplace=False)
 
 
-def test_transform_rectilinear_raises_leaves_input_unchanged(rectilinear):
-    rectilinear['a'] = np.arange(rectilinear.n_points, dtype=float)
-    rectilinear['b'] = np.arange(rectilinear.n_points, dtype=float)
-    rectilinear.set_active_scalars('a')
-    before = rectilinear.copy()
+SHEAR_MATRIX = np.eye(4)
+SHEAR_MATRIX[0, 1] = 0.1
+SHEAR_MATRIX[1, 0] = 0.1
 
-    with pytest.raises(ValueError, match='non-diagonal rotation component'):
-        rectilinear.transform(pv.Transform().rotate_x(30), inplace=False)
 
-    assert rectilinear.active_scalars_name == 'a'
-    assert rectilinear == before
+@pytest.mark.parametrize('inplace', [True, False])
+@pytest.mark.parametrize(
+    ('grid', 'transformation', 'match'),
+    [
+        ('rectilinear', pv.Transform().rotate_x(30), 'non-diagonal rotation component'),
+        ('rectilinear', SHEAR_MATRIX, 'shear component'),
+        ('uniform', SHEAR_MATRIX, 'shear component'),
+    ],
+    ids=['rectilinear-rotation', 'rectilinear-shear', 'image-shear'],
+)
+def test_transform_raises_leaves_input_unchanged(grid, transformation, match, inplace, request):
+    mesh = request.getfixturevalue(grid)
+    mesh['a'] = np.arange(mesh.n_points, dtype=float)
+    mesh['b'] = np.arange(mesh.n_points, dtype=float)
+    mesh.set_active_scalars('a')
+    before = mesh.copy()
+
+    with pytest.raises(ValueError, match=match):
+        mesh.transform(transformation, inplace=inplace)
+
+    assert mesh.active_scalars_name == 'a'
+    assert mesh == before
 
 
 def test_transform_rectilinear(rectilinear):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2593,8 +2593,30 @@ def test_transform_copy(multiply_mode):
     assert t2.point == t1.point
     assert t2.check_finite == t1.check_finite
 
-    # The copy composes about the same point as the original
+    # The copy composes about the same point and validates the same way
     assert np.array_equal(t1.scale(SCALE).matrix, t2.scale(SCALE).matrix)
+    t2.compose(np.diag([1.0, np.nan, 1.0, 1.0]))
+
+
+@pytest.mark.parametrize(
+    ('operation', 'expected'),
+    [
+        (lambda t: t * 2, lambda t: t.copy().scale(2)),
+        (lambda t: 2 * t, lambda t: t.copy().scale(2, multiply_mode='pre')),
+        (lambda t: t + (1, 2, 3), lambda t: t.copy().translate((1, 2, 3))),  # noqa: RUF005
+        (lambda t: (1, 2, 3) + t, lambda t: t.copy().translate((1, 2, 3), multiply_mode='pre')),  # noqa: RUF005
+    ],
+    ids=['mul', 'rmul', 'add', 'radd'],
+)
+def test_transform_operators_compose_about_the_origin(operation, expected):
+    with_point = Transform(point=(1, 2, 3))
+    without_point = Transform()
+
+    actual = operation(with_point)
+
+    assert np.array_equal(actual.matrix, operation(without_point).matrix)
+    assert np.array_equal(actual.matrix, expected(without_point).matrix)
+    assert actual.n_transformations == 1
 
 
 def test_transform_repr(transform):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2584,10 +2584,17 @@ def test_transform_mul_raises():
 def test_transform_copy(multiply_mode):
     t1 = Transform().scale(SCALE)
     t1.multiply_mode = multiply_mode
+    t1.point = (1, 2, 3)
+    t1.check_finite = False
     t2 = t1.copy()
     assert np.array_equal(t1.matrix, t2.matrix)
     assert t1 is not t2
     assert t2.multiply_mode == t1.multiply_mode
+    assert t2.point == t1.point
+    assert t2.check_finite == t1.check_finite
+
+    # The copy composes about the same point as the original
+    assert np.array_equal(t1.scale(SCALE).matrix, t2.scale(SCALE).matrix)
 
 
 def test_transform_repr(transform):


### PR DESCRIPTION
### Overview

Two bugs and two speedups in `Transform` and the `transform` filter, one commit each.

- `Transform.copy()` restored the multiply mode but silently dropped `point` and `check_finite`, so a copy composed rotations and scalings about the origin instead of the transform's point, and validated matrices the original was set to leave alone. The `*` operator works on a copy and keeps composing about the origin, which its docstring now states.
- The filter clears the input's active scalars as a `vtkTransformFilter` workaround and restored them only on success, so any failure in between left the caller's mesh with no active scalars: an `ImageData` or `RectilinearGrid` rejecting a transformation it cannot represent, and errors from the filter itself. They are now restored in a `finally`, and a rejected `RectilinearGrid` transformation is caught before the filter runs at all.
- `axis_angle_rotation` and `reflection` checked one vector's length with `numpy.isclose`, which costs more than building the matrix; the same comparison is made directly, with the tolerances `numpy.isclose` uses.
- Composing about a point built two full `Transform` objects for the translations to and from it; plain `vtkTransform` objects are used instead, since that is what gets composed either way.

| Call (min of 5 on this machine) | Before | After |
| --- | ---: | ---: |
| `Transform().rotate_z(30)` | 29.9 µs | 17.1 µs |
| `Transform().flip_x()` | 25.3 µs | 14.1 µs |
| `Transform().scale(2, point=(1, 2, 3))` | 21.5 µs | 10.7 µs |
| `Transform().rotate_z(30, point=(1, 2, 3))` | 33.3 µs | 21.9 µs |
| a chain of five compositions | 64.6 µs | 41.7 µs |

The filter's own branching is tidied up along the way: choosing what to transform, converting integer arrays, and building each kind of output are now functions, so the part that runs the filter is visible among them. Output is unchanged for 224 combinations of dataset type, transformation, `inplace` and `transform_all_input_vectors`.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
