### PR TITLE
Give each text property its own theme

### DIFF
--- a/pyvista/plotting/plot_compare.py
+++ b/pyvista/plotting/plot_compare.py
@@ -324,8 +324,7 @@ def _validate_label_position(label_position: Any) -> TextPositionOptions | None:
 
 def _text_width(text: str, prop: Any, *, size: float, dpi: int, measurer: Any) -> float:
     """Return the width in pixels of the text drawn at the given font size."""
-    # A `pyvista.TextProperty` loads the theme into a property shared by all of them,
-    # which measuring has no business doing, so measure with a plain VTK one
+    # Measure with a plain VTK property, which needs no theme
     measured = _vtk.vtkTextProperty()
     # Copy what the text is drawn with, to measure its font rather than the default
     measured.ShallowCopy(prop)

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -430,7 +430,7 @@ class Label(_Prop3DMixin, Text):
 
     @_label_position.setter
     def _label_position(self, position: VectorLike[float]):
-        valid_position = _validation.validate_array3(position)
+        valid_position = _validation.validate_array3(position, dtype_out=float, to_tuple=True)
         self.GetPositionCoordinate().SetValue(valid_position)
 
     @property

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -430,7 +430,7 @@ class Label(_Prop3DMixin, Text):
 
     @_label_position.setter
     def _label_position(self, position: VectorLike[float]):
-        valid_position = _validation.validate_array3(position, dtype_out=float, to_tuple=True)
+        valid_position = _validation.validate_array3(position)
         self.GetPositionCoordinate().SetValue(valid_position)
 
     @property
@@ -537,7 +537,6 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
 
     """
 
-    _theme = Theme()
     _color_set = None
     _background_color_set = None
     _font_family = None
@@ -561,12 +560,7 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
     ):
         """Initialize text's property."""
         super().__init__()
-        if theme is None:
-            # copy global theme to ensure local property theme is fixed
-            # after creation.
-            self._theme.load_theme(pv.global_theme)
-        else:
-            self._theme.load_theme(theme)
+        self._theme = Theme._from_theme(pv.global_theme if theme is None else theme)
         self.color = color
         self.font_family = font_family
         if orientation is not None:

--- a/tests/plotting/test_text.py
+++ b/tests/plotting/test_text.py
@@ -336,3 +336,18 @@ def test_add_text_actor_follows_the_theme_of_the_plotter():
     assert actor.prop.color == pv.Color('blue')
     assert actor.prop.font_family == 'times'
     pl.close()
+
+
+def test_text_property_theme_is_not_shared():
+    """Test that a property keeps its own theme when another property is created."""
+    theme = pv.themes.Theme()
+    theme.font.color = 'red'
+    custom = pv.TextProperty(theme=theme)
+
+    # A property made from the global theme does not take the custom theme's color
+    default = pv.TextProperty()
+    assert default.color == pv.Color(pv.global_theme.font.color)
+
+    # Nor does it leave the custom property resolving colors from the global theme
+    custom.color = None
+    assert custom.color == pv.Color('red')


### PR DESCRIPTION
### Overview

`TextProperty` held its theme in a class attribute and loaded into it on every construction, so every text property shared one theme: creating a property with a custom theme changed the colors and fonts of all the others, including ones already created. Each property now takes its own snapshot, the way `Property`, `DataSetMapper` and `Plotter` already do.

Split out of #9127.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
