### PR TITLE
Copy the transformation matrix in Light.from_vtk

### DIFF
--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -1141,6 +1141,10 @@ class Light(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLight):
         light.cone_angle = vtk_light.GetConeAngle()
         light.attenuation_values = vtk_light.GetAttenuationValues()
         trans = vtk_light.GetTransformMatrix()
+        if trans is not None:
+            matrix = _vtk.vtkMatrix4x4()
+            matrix.DeepCopy(trans)
+            trans = matrix
         light.transform_matrix = trans
         light.shadow_attenuation = vtk_light.GetShadowAttenuation()
 

--- a/tests/plotting/test_lights.py
+++ b/tests/plotting/test_lights.py
@@ -314,6 +314,12 @@ def test_from_vtk():
         else:
             assert getattr(light, pvname) == value
 
+    # the transformation matrix is copied, not shared with the source light
+    source_matrix = vtk_light.GetTransformMatrix()
+    assert light.transform_matrix is not source_matrix
+    source_matrix.SetElement(0, 3, 42.0)
+    assert light.transform_matrix.GetElement(0, 3) != 42.0
+
     # invalid case
     with pytest.raises(TypeError):
         pv.Light.from_vtk('invalid')


### PR DESCRIPTION
### Overview

`Light.from_vtk` documents that it returns a copy, but it assigned the source light's transformation matrix by reference, so later edits to the source light reached the new one. It is now deep copied, as `Light.copy` already does.

Split out of #9127.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
