### PR TITLE
Remove an actor's mapper from every scalar bar holding it

### DIFF
--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -92,7 +92,6 @@ class ScalarBars(_NoNewAttrMixin):
                         render=render,
                     )
                     self._plotter._scalar_bar_slots.add(slot)
-            return
 
     @_deprecate_positional_args(allowed=['title'])
     def remove_scalar_bar(self, title=None, render: bool = True):  # noqa: FBT001, FBT002

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -187,3 +187,18 @@ def test_add_scalar_bar_shared_range_resync(sphere):
     actors.append(pl.add_mesh(mid.copy(), scalars='data'))
     assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 6
     pl.close()
+
+
+def test_remove_actor_removes_mapper_from_every_scalar_bar(sphere):
+    """Test that removing an actor clears its mapper from all of its scalar bars."""
+    sphere[KEY] = sphere.points[:, 2]
+    pl = pv.Plotter()
+    actor = pl.add_mesh(sphere, scalars=KEY)
+    pl.add_scalar_bar('Second')
+    mappers = pl.scalar_bars._scalar_bar_mappers
+    assert [title for title, m in mappers.items() if actor.mapper in m] == [KEY, 'Second']
+
+    pl.remove_actor(actor)
+    assert [title for title, m in mappers.items() if actor.mapper in m] == []
+    assert len(pl.scalar_bars) == 0
+    pl.close()


### PR DESCRIPTION
### Overview

Removing an actor clears its mapper from the scalar bars holding it, but the loop over the titles returned after its first iteration. A mapper shown under more than one title was removed from only the first, and the other bars kept a mapper whose actor was gone.

Split out of #9127.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
