### PR TITLE
Fix how color_labels reads labels and colormap colors

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7893,9 +7893,10 @@ class DataSetFilters(DataObjectFilters):
                 )
                 raise ValueError(msg)
 
-        def _is_index_like(array_, max_value):
-            min_value = -max_value if negative_indexing else 0
-            return (array_ == np.floor(array_)) & (array_ >= min_value) & (array_ <= max_value)
+        def _is_index_like(array_, n_colors_):
+            """Return which values can be used to index ``n_colors_`` colors."""
+            min_value = -n_colors_ if negative_indexing else 0
+            return (array_ == np.floor(array_)) & (array_ >= min_value) & (array_ < n_colors_)
 
         _validation.check_contains(
             ['int_rgb', 'float_rgb', 'int_rgba', 'float_rgba'],
@@ -7966,14 +7967,26 @@ class DataSetFilters(DataObjectFilters):
                         raise TypeError(msg)
                     # Avoid unnecessary conversion and set color sequence directly in float cases
                     cmap_colors = cast('list[list[float]]', cmap.colors)
-                    if color_type == 'float_rgb':
-                        color_rgb_sequence = cmap_colors
+                    # Only float RGB or RGBA rows can be used without validating them
+                    color_array = np.asarray(cmap_colors)
+                    n_channels = (
+                        color_array.shape[1]
+                        if color_array.ndim == 2 and color_array.dtype.kind == 'f'
+                        else 0
+                    )
+                    if color_type == 'float_rgb' and n_channels in (3, 4):
+                        color_rgb_sequence = (
+                            cmap_colors if n_channels == 3 else [c[:3] for c in cmap_colors]
+                        )
                         _is_rgb_sequence = True
-                    elif color_type == 'float_rgba':
-                        color_rgb_sequence = [(*c, 1.0) for c in cmap_colors]
+                    elif color_type == 'float_rgba' and n_channels in (3, 4):
+                        color_rgb_sequence = (
+                            cmap_colors if n_channels == 4 else [[*c, 1.0] for c in cmap_colors]
+                        )
                         _is_rgb_sequence = True
                     else:
-                        colors = cmap_colors
+                        # The colors may be an array, which is not a valid color sequence
+                        colors = color_array.tolist()
 
             table = None
             if not _is_rgb_sequence:
@@ -7990,7 +8003,7 @@ class DataSetFilters(DataObjectFilters):
                     color_rgb_sequence = color_rgb_sequence * len(array)
 
             n_colors = len(color_rgb_sequence)
-            index_like = np.all(_is_index_like(array, max_value=n_colors))
+            index_like = np.all(_is_index_like(array, n_colors_=n_colors))
             if coloring_mode is None:
                 coloring_mode = 'index' if index_like else 'cycle'
 
@@ -8019,11 +8032,9 @@ class DataSetFilters(DataObjectFilters):
                     mapping = {
                         label: color_rgb_sequence[label] for label in keys if label in present
                     }
-                # Negative labels index the sequence from the end like the negative keys, and
-                # a label equal to ``n_colors`` passes the check above but has no color
+                # Negative labels index the sequence from the end like the negative keys
                 indices[indices < 0] += n_colors
-                default_row = np.full((1, num_components), default_channel_value, color_dtype)
-                colors_out = np.vstack((table, default_row))[indices]
+                colors_out = table[indices]
             else:  # 'cycle', validated above
                 if negative_indexing:
                     msg = "Negative indexing is not supported with 'cycle' mode enabled."
@@ -8490,7 +8501,7 @@ class DataSetFilters(DataObjectFilters):
             dimensions_ = _validation.validate_array3(
                 dimensions, must_be_integer=True, dtype_out=int, name='dimensions'
             )
-            dimensions = dimensions_ - 1
+            dimensions = cast('NumpyArray[int]', dimensions_) - 1
 
         binary_mask = self.voxelize_binary_mask(
             background_value=background_value,
@@ -8924,7 +8935,7 @@ def _validate_extraction_ids(
                 f'Number of bool indices ({ids.size}) must match the number of {name} ({n_items}).'
             )
             raise ValueError(msg)
-        mask = ids.astype(bool, copy=False)
+        mask = ids
     else:
         mask = np.zeros(n_items, dtype=bool)
         if ids.size:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -8501,7 +8501,7 @@ class DataSetFilters(DataObjectFilters):
             dimensions_ = _validation.validate_array3(
                 dimensions, must_be_integer=True, dtype_out=int, name='dimensions'
             )
-            dimensions = cast('NumpyArray[int]', dimensions_) - 1
+            dimensions = dimensions_ - 1
 
         binary_mask = self.voxelize_binary_mask(
             background_value=background_value,
@@ -8935,7 +8935,7 @@ def _validate_extraction_ids(
                 f'Number of bool indices ({ids.size}) must match the number of {name} ({n_items}).'
             )
             raise ValueError(msg)
-        mask = ids
+        mask = ids.astype(bool, copy=False)
     else:
         mask = np.zeros(n_items, dtype=bool)
         if ids.size:

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4973,8 +4973,7 @@ def test_color_labels_return_dict(labeled_image, color_type):
     ('negative_indexing', 'label_data', 'expected_keys'),
     [
         (True, [0, -1, 2, -6], [0, 2, -1, -6]),
-        # A label equal to the number of colors is allowed but has no color
-        (False, [0, 2, 2, 6], [0, 2]),
+        (False, [0, 2, 2, 5], [0, 2, 5]),
     ],
 )
 def test_color_labels_return_dict_index_mode(negative_indexing, label_data, expected_keys):
@@ -4988,8 +4987,25 @@ def test_color_labels_return_dict_index_mode(negative_indexing, label_data, expe
     assert list(mapping.keys()) == expected_keys
     for key in expected_keys:
         assert mapping[key] == pv.Color(colors[key]).int_rgb
-    expected_colors = [mapping.get(label, (0, 0, 0)) for label in label_data]
+    expected_colors = [mapping[label] for label in label_data]
     assert np.array_equal(colored.active_scalars, expected_colors)
+
+
+def test_color_labels_label_equal_to_number_of_colors():
+    colors = ['red', 'green', 'blue']
+    labels = pv.ImageData(dimensions=(4, 1, 1))
+    labels['data'] = [0, 1, 2, 3]
+
+    # A label equal to the number of colors cannot index the colors
+    match = 'Index coloring mode cannot be used'
+    with pytest.raises(ValueError, match=match):
+        labels.color_labels(colors, coloring_mode='index')
+
+    # Cycle mode is used by default instead, so every label is colored
+    colored, mapping = labels.color_labels(colors, return_dict=True)
+    assert list(mapping.keys()) == [0, 1, 2, 3]
+    assert mapping[3] == pv.Color('red').int_rgb
+    assert np.array_equal(colored.active_scalars, [mapping[label] for label in labels['data']])
 
 
 def test_color_labels_does_not_modify_colormap():
@@ -5001,6 +5017,53 @@ def test_color_labels_does_not_modify_colormap():
     second = labels.color_labels(cmap, **kwargs)
     assert len(cmap.colors) == 2
     assert np.array_equal(first.active_scalars, second.active_scalars)
+
+
+@pytest.mark.parametrize('as_array', [True, False])
+@pytest.mark.parametrize(
+    ('color_type', 'red', 'green', 'opaque', 'quarter'),
+    [
+        ('float_rgb', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), None, None),
+        ('float_rgba', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), 1.0, 0.25),
+        ('int_rgb', (255, 0, 0), (0, 255, 0), None, None),
+        ('int_rgba', (255, 0, 0), (0, 255, 0), 255, 64),
+    ],
+)
+def test_color_labels_listed_colormap_colors(as_array, color_type, red, green, opaque, quarter):
+    rgb = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    rgba = [(*color, 0.25) for color in rgb]
+    labels = pv.ImageData(dimensions=(3, 1, 1))
+    labels['data'] = [0, 1, 0]
+
+    def colors_of(colors):
+        cmap = ListedColormap(np.array(colors) if as_array else colors)
+        colored = labels.color_labels(cmap, coloring_mode='index', color_type=color_type)
+        return np.asarray(colored.active_scalars)
+
+    assert np.allclose(colors_of(rgb)[:, :3], [red, green, red])
+    assert np.allclose(colors_of(rgba)[:, :3], [red, green, red])
+    if opaque is not None:
+        assert np.allclose(colors_of(rgb)[:, 3], opaque)
+        # The colormap's own alpha is used when it has one
+        assert np.allclose(colors_of(rgba)[:, 3], quarter)
+
+
+@pytest.mark.parametrize('as_array', [True, False])
+@pytest.mark.parametrize('color_type', ['float_rgb', 'float_rgba', 'int_rgb', 'int_rgba'])
+def test_color_labels_return_dict_listed_colormap(as_array, color_type):
+    colors = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    cmap = ListedColormap(np.array(colors) if as_array else colors)
+    labels = pv.ImageData(dimensions=(3, 1, 1))
+    labels['data'] = [0, 1, 0]
+
+    colored, mapping = labels.color_labels(
+        cmap, coloring_mode='index', color_type=color_type, return_dict=True
+    )
+
+    assert list(mapping.keys()) == [0, 1]
+    for label, color in mapping.items():
+        assert pv.Color(color) == pv.Color(colors[label])
+        assert np.array_equal(colored.active_scalars[label], color)
 
 
 def test_color_labels_return_dict_cycle_mode():


### PR DESCRIPTION
### Overview

Two bugs in `DataSetFilters.color_labels`.

- A label equal to the number of colors was accepted as an index, although only labels below that count can index the colors, as the error message for out-of-range labels already says. Such a label silently kept the default color in index mode instead of raising, and suppressed the fall back to cycle mode when no coloring mode was given.
- The colors of a `ListedColormap` were assumed to be a list of RGB triples. RGBA colors raised a numpy shape error for the float color types, and an array of colors, as `ListedColormap(colormap(numpy.linspace(0, 1, n)))` produces, was rejected as an invalid color sequence for the integer types. Both forms are now read, and their alpha is kept for the float color types as it already was for the integer ones.

Split out of #9127.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
