### PR TITLE
Reject a volume of interest outside the image in extract_subset

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -449,7 +449,7 @@ class ImageDataFilters(DataSetFilters):
         voi : sequence[int]
             Length 6 iterable of ``int``\ s: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
             These bounds specify the volume of interest in i-j-k min/max
-            indices.
+            indices. Must be within this mesh's :attr:`~pyvista.ImageData.extent`.
 
         rate : sequence[int], default: (1, 1, 1)
             Length 3 iterable of ``int``\ s: ``(xrate, yrate, zrate)``.
@@ -493,6 +493,17 @@ class ImageDataFilters(DataSetFilters):
         crop
 
         """
+        voi = _validation.validate_arrayN(
+            voi, must_have_length=6, must_be_integer=True, dtype_out=int, name='voi'
+        )
+        extent = self.extent
+        if np.any(np.not_equal(ImageDataFilters._clip_extent(voi, clip_to=extent), voi)):
+            msg = (
+                f'The requested volume of interest {tuple(voi.tolist())} '
+                f"is outside the input's extent {extent}."
+            )
+            raise ValueError(msg)
+
         alg = _vtk.vtkExtractVOI()
         alg.SetVOI(voi)
         alg.SetInputDataObject(self)
@@ -603,7 +614,8 @@ class ImageDataFilters(DataSetFilters):
 
         extent : VectorLike[int], optional
             Length-6 vector of integers specifying the full :attr:`~pyvista.ImageData.extent` of
-            the cropping region.
+            the cropping region. If the region extends beyond the extents of this mesh, it is
+            clipped to the part this mesh covers.
 
         normalized_bounds : VectorLike[float], optional
             Normalized bounds relative to the input. These are floats between ``0.0`` and ``1.0``
@@ -687,7 +699,7 @@ class ImageDataFilters(DataSetFilters):
             Threshold-like filter which may be used to generate a mask for cropping.
 
         extract_subset
-            Equivalent filter to ``crop(extent=voi, rebase_coordinates=True)``.
+            Similar filter which requires the region to be inside the image.
 
         Examples
         --------
@@ -843,10 +855,10 @@ class ImageDataFilters(DataSetFilters):
             default_background = 0.0
             background = default_background if background_value is None else background_value
             if num_components > 1:
-                background_array = _validation.validate_arrayN(
+                background = _validation.validate_arrayN(
                     background, name='background_value', must_have_length=(1, num_components)
                 )
-                mask_array = np.any(array != background_array, axis=1)
+                mask_array = np.any(array != background, axis=1)
             else:
                 background = _validation.validate_number(background, name='background_value')
                 mask_array = array != background
@@ -1003,6 +1015,9 @@ class ImageDataFilters(DataSetFilters):
         voi[1] = max(voi[0:2])
         voi[3] = max(voi[2:4])
         voi[5] = max(voi[4:6])
+
+        # Crop to the part of the requested region which the image actually covers
+        voi = ImageDataFilters._clip_extent(voi, clip_to=self.extent)
 
         cropped = self.extract_subset(
             voi, rebase_coordinates=rebase_coordinates, progress_bar=progress_bar
@@ -4144,9 +4159,7 @@ class ImageDataFilters(DataSetFilters):
         """
         dimensions = np.asarray(self.dimensions)  # type: ignore[attr-defined]
         # Build an array of the operation size
-        operation_size = _validation.validate_array3(
-            operation_size, reshape=True, broadcast=True, must_be_integer=True, dtype_out=int
-        )
+        operation_size = _validation.validate_array3(operation_size, reshape=True, broadcast=True)
 
         if not isinstance(operation_mask, str) and operation_mask not in [0, 1, 2, 3]:
             # Build a bool array of the mask
@@ -4156,7 +4169,6 @@ class ImageDataFilters(DataSetFilters):
                 broadcast=False,
                 must_have_dtype=bool,
                 must_be_real=False,
-                dtype_out=bool,
             )
 
         elif operation_mask == 'preserve':

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -855,10 +855,10 @@ class ImageDataFilters(DataSetFilters):
             default_background = 0.0
             background = default_background if background_value is None else background_value
             if num_components > 1:
-                background = _validation.validate_arrayN(
+                background_array = _validation.validate_arrayN(
                     background, name='background_value', must_have_length=(1, num_components)
                 )
-                mask_array = np.any(array != background, axis=1)
+                mask_array = np.any(array != background_array, axis=1)
             else:
                 background = _validation.validate_number(background, name='background_value')
                 mask_array = array != background
@@ -4159,7 +4159,9 @@ class ImageDataFilters(DataSetFilters):
         """
         dimensions = np.asarray(self.dimensions)  # type: ignore[attr-defined]
         # Build an array of the operation size
-        operation_size = _validation.validate_array3(operation_size, reshape=True, broadcast=True)
+        operation_size = _validation.validate_array3(
+            operation_size, reshape=True, broadcast=True, must_be_integer=True, dtype_out=int
+        )
 
         if not isinstance(operation_mask, str) and operation_mask not in [0, 1, 2, 3]:
             # Build a bool array of the mask
@@ -4169,6 +4171,7 @@ class ImageDataFilters(DataSetFilters):
                 broadcast=False,
                 must_have_dtype=bool,
                 must_be_real=False,
+                dtype_out=bool,
             )
 
         elif operation_mask == 'preserve':

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3674,6 +3674,18 @@ def test_extract_subset(uniform, rebase_coordinates):
     assert cropped == voi
 
 
+@pytest.mark.parametrize(
+    'voi',
+    [(-5, 5, 0, 5, 0, 5), (0, 100, 0, 5, 0, 5), (0, 5, 0, 5, 0, 100)],
+)
+def test_extract_subset_voi_outside_extent_raises(uniform, voi):
+    match = (
+        f"The requested volume of interest {voi} is outside the input's extent {uniform.extent}."
+    )
+    with pytest.raises(ValueError, match=re.escape(match)):
+        uniform.extract_subset(voi)
+
+
 def test_gaussian_smooth_output_type():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -1084,6 +1084,16 @@ def test_validate_dim_operation_invalid_parameters(
         )
 
 
+@pytest.mark.parametrize('operation_size', [1.5, (1, 2, 2.5)])
+def test_validate_dim_operation_rejects_fractional_size(operation_size):
+    # The size is cast to an integer dtype, which would otherwise truncate it silently
+    image = pv.ImageData(dimensions=(5, 5, 5))
+    with pytest.raises(ValueError, match='must have integer-like values'):
+        image._validate_dimensional_operation(
+            operation_mask='preserve', operator=operator.add, operation_size=operation_size
+        )
+
+
 @pytest.mark.parametrize('spacing', [None, [0.3, 0.4, 0.5]])
 @pytest.mark.parametrize('direction_matrix', [None, np.diag((-1, 1, 1))])
 @pytest.mark.parametrize('origin', [None, (1.1, 2.2, 3.3)])

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -1084,16 +1084,6 @@ def test_validate_dim_operation_invalid_parameters(
         )
 
 
-@pytest.mark.parametrize('operation_size', [1.5, (1, 2, 2.5)])
-def test_validate_dim_operation_rejects_fractional_size(operation_size):
-    # The size is cast to an integer dtype, which would otherwise truncate it silently
-    image = pv.ImageData(dimensions=(5, 5, 5))
-    with pytest.raises(ValueError, match='must have integer-like values'):
-        image._validate_dimensional_operation(
-            operation_mask='preserve', operator=operator.add, operation_size=operation_size
-        )
-
-
 @pytest.mark.parametrize('spacing', [None, [0.3, 0.4, 0.5]])
 @pytest.mark.parametrize('direction_matrix', [None, np.diag((-1, 1, 1))])
 @pytest.mark.parametrize('origin', [None, (1.1, 2.2, 3.3)])
@@ -2045,6 +2035,16 @@ def test_crop_keep_dimensions(image2x2, fill_value):
 
     # Test field data is preserved
     assert cropped.user_dict == user_dict
+
+
+def test_crop_clips_to_the_image_extent(uncropped_image):
+    extent = uncropped_image.extent
+    oversized = (extent[0] - 5, extent[1] + 5, extent[2], extent[3], extent[4], extent[5])
+
+    cropped = uncropped_image.crop(extent=oversized)
+
+    assert cropped.extent == extent
+    assert cropped == uncropped_image.crop(extent=extent)
 
 
 def test_crop_raises():


### PR DESCRIPTION
### Overview

VTK clamps a volume of interest to the extent of its input and reports the problem only to its own log, while `extract_subset` went on to place the output using the requested indices. Extracting `(-5, 5, ...)` from an image starting at zero returned the same voxels as `(0, 5, ...)` but positioned them five voxels away, silently. Such a volume of interest is now rejected, in the wording `slice_index` already uses for the same condition.

`crop` clips its region to the image before extracting, so it keeps returning the part of the requested region that exists, and its documentation now says so.

Split out of #9127.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
