### PR TITLE
Type what the clip and slice filters return

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -5824,19 +5824,24 @@ def _clip_by_box_planes(
     inside: DataSet = dataset
     outside = []
     for normal, origin in planes:
-        result = inside.clip(
-            normal=normal,
-            origin=origin,
-            invert=True,
-            return_clipped=invert,
-            progress_bar=progress_bar,
-        )
         if invert:
-            inside, piece = result
+            inside, piece = inside.clip(
+                normal=normal,
+                origin=origin,
+                invert=True,
+                return_clipped=True,
+                progress_bar=progress_bar,
+            )
             if piece.n_cells:
                 outside.append(piece)
         else:
-            inside = result
+            inside = inside.clip(
+                normal=normal,
+                origin=origin,
+                invert=True,
+                return_clipped=False,
+                progress_bar=progress_bar,
+            )
     if not invert:
         return inside
     if not outside:

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -21,6 +21,7 @@ from typing import NamedTuple
 from typing import TypeVar
 from typing import cast
 from typing import get_args
+from typing import overload
 import warnings
 
 import numpy as np
@@ -59,10 +60,12 @@ if TYPE_CHECKING:
     from pyvista import DataSetAttributes
     from pyvista import ImageData
     from pyvista import MultiBlock
+    from pyvista import PointSet
     from pyvista import PolyData
     from pyvista import RectilinearGrid
     from pyvista import RotationLike
     from pyvista import TransformLike
+    from pyvista import UnstructuredGrid
     from pyvista import VectorLike
     from pyvista import pyvista_ndarray
     from pyvista.core._typing_core import NumpyArray
@@ -3242,6 +3245,136 @@ class DataObjectFilters:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
         return _maybe_cast_to_point_set(clipped)
 
+    @overload
+    def clip(  # type: ignore[misc]
+        self: PolyData,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[False] = False,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> PolyData: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: PolyData,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[True] = True,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> tuple[PolyData, PolyData]: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: PointSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[False] = False,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> PointSet: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: PointSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[True] = True,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> tuple[PointSet, PointSet]: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[False] = False,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> UnstructuredGrid: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: Literal[True] = True,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: MultiBlock,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: Literal[False] = False,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> MultiBlock: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: MultiBlock,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: Literal[True] = True,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> tuple[MultiBlock, MultiBlock]: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: DataSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: Literal[False] = False,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> UnstructuredGrid: ...
+    @overload
+    def clip(  # type: ignore[misc]
+        self: DataSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: Literal[True] = True,  # noqa: FBT002
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
     @_deprecate_positional_args(allowed=['normal'])
     def clip(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3379,6 +3512,36 @@ class DataObjectFilters:
                 return self
         return result
 
+    @overload
+    def clip_box(  # type: ignore[misc]
+        self: PointSet,
+        bounds: float | VectorLike[float] | PolyData | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        factor: float = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        merge_points: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> PointSet: ...
+    @overload
+    def clip_box(  # type: ignore[misc]
+        self: MultiBlock,
+        bounds: float | VectorLike[float] | PolyData | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        factor: float = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        merge_points: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> MultiBlock: ...
+    @overload
+    def clip_box(  # type: ignore[misc]
+        self: DataSet,
+        bounds: float | VectorLike[float] | PolyData | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        factor: float = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        merge_points: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> UnstructuredGrid: ...
     @_deprecate_positional_args(allowed=['bounds'])
     def clip_box(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3575,6 +3738,54 @@ class DataObjectFilters:
         clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
         return _cast_output_to_match_input_type(clipped, self)
 
+    @overload
+    def clip_slab(  # type: ignore[misc]
+        self: PolyData,
+        thickness: float,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        *,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,
+        progress_bar: bool = ...,
+        crinkle: bool = ...,
+        plane: PolyData | None = ...,
+    ) -> PolyData: ...
+    @overload
+    def clip_slab(  # type: ignore[misc]
+        self: PointSet,
+        thickness: float,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        *,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,
+        progress_bar: bool = ...,
+        crinkle: bool = ...,
+        plane: PolyData | None = ...,
+    ) -> PointSet: ...
+    @overload
+    def clip_slab(  # type: ignore[misc]
+        self: MultiBlock,
+        thickness: float,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        *,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,
+        progress_bar: bool = ...,
+        crinkle: bool = ...,
+        plane: PolyData | None = ...,
+    ) -> MultiBlock: ...
+    @overload
+    def clip_slab(  # type: ignore[misc]
+        self: DataSet,
+        thickness: float,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        *,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,
+        progress_bar: bool = ...,
+        crinkle: bool = ...,
+        plane: PolyData | None = ...,
+    ) -> UnstructuredGrid: ...
     def clip_slab(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,
         thickness: float,
@@ -3703,6 +3914,22 @@ class DataObjectFilters:
         result = _cast_output_to_match_input_type(result, self)
         return _remove_unused_points_post_clip(result, input_bounds)
 
+    @overload
+    def slice_implicit(  # type: ignore[misc]
+        self: MultiBlock,
+        implicit_function: _vtk.vtkImplicitFunction,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> MultiBlock: ...
+    @overload
+    def slice_implicit(  # type: ignore[misc]
+        self: DataSet,
+        implicit_function: _vtk.vtkImplicitFunction,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> PolyData: ...
     @_deprecate_positional_args(allowed=['implicit_function'])
     def slice_implicit(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3804,6 +4031,26 @@ class DataObjectFilters:
             return output.contour()
         return output
 
+    @overload
+    def slice(  # type: ignore[misc]
+        self: MultiBlock,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> MultiBlock: ...
+    @overload
+    def slice(  # type: ignore[misc]
+        self: DataSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> PolyData: ...
     @_deprecate_positional_args(allowed=['normal'])
     def slice(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3958,7 +4205,7 @@ class DataObjectFilters:
         generate_triangles: bool = False,  # noqa: FBT001, FBT002
         contour: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
-    ):
+    ) -> MultiBlock:
         """Create three orthogonal slices through the dataset on the three Cartesian planes.
 
         Yields a MutliBlock dataset of the three slices.
@@ -4080,7 +4327,7 @@ class DataObjectFilters:
         bounds=None,
         center=None,
         progress_bar: bool = False,  # noqa: FBT001, FBT002
-    ):
+    ) -> MultiBlock:
         """Create many slices of the input dataset along a specified axis.
 
         Parameters
@@ -4221,6 +4468,22 @@ class DataObjectFilters:
             output.append(slc, f'slice{i}')
         return output
 
+    @overload
+    def slice_along_line(  # type: ignore[misc]
+        self: MultiBlock,
+        line: pv.PolyData,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> MultiBlock: ...
+    @overload
+    def slice_along_line(  # type: ignore[misc]
+        self: DataSet,
+        line: pv.PolyData,
+        generate_triangles: bool = ...,  # noqa: FBT001
+        contour: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> PolyData: ...
     @_deprecate_positional_args(allowed=['line'])
     def slice_along_line(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3245,201 +3245,40 @@ class DataObjectFilters:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
         return _maybe_cast_to_point_set(clipped)
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # PolyData, return_clipped=False
-    def clip(  # type: ignore[misc]
-        self: PolyData,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> PolyData: ...
+    def clip(self: PolyData, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[False] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PolyData: ...  # type: ignore[misc]
     @overload  # PolyData, return_clipped=True
-    def clip(  # type: ignore[misc]
-        self: PolyData,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> tuple[PolyData, PolyData]: ...
+    def clip(self: PolyData, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[True] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> tuple[PolyData, PolyData]: ...  # type: ignore[misc]
     @overload  # PolyData, return_clipped not known
-    def clip(  # type: ignore[misc]
-        self: PolyData,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> PolyData | tuple[PolyData, PolyData]: ...
+    def clip(self: PolyData, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PolyData | tuple[PolyData, PolyData]: ...  # type: ignore[misc]
     @overload  # PointSet, return_clipped=False
-    def clip(  # type: ignore[misc]
-        self: PointSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> PointSet: ...
+    def clip(self: PointSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[False] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PointSet: ...  # type: ignore[misc]
     @overload  # PointSet, return_clipped=True
-    def clip(  # type: ignore[misc]
-        self: PointSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> tuple[PointSet, PointSet]: ...
+    def clip(self: PointSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[True] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> tuple[PointSet, PointSet]: ...  # type: ignore[misc]
     @overload  # PointSet, return_clipped not known
-    def clip(  # type: ignore[misc]
-        self: PointSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> PointSet | tuple[PointSet, PointSet]: ...
+    def clip(self: PointSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PointSet | tuple[PointSet, PointSet]: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, return_clipped=False
-    def clip(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> UnstructuredGrid: ...
+    def clip(self: UnstructuredGrid, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[False] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, return_clipped=True
-    def clip(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip(self: UnstructuredGrid, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: Literal[True] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, return_clipped not known
-    def clip(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        return_clipped: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip(self: UnstructuredGrid, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: bool = ..., return_clipped: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # MultiBlock, return_clipped=False
-    def clip(  # type: ignore[misc]
-        self: MultiBlock,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> MultiBlock: ...
+    def clip(self: MultiBlock, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: Literal[False] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # MultiBlock, return_clipped=True
-    def clip(  # type: ignore[misc]
-        self: MultiBlock,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: Literal[True] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> tuple[MultiBlock, MultiBlock]: ...
+    def clip(self: MultiBlock, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: Literal[True] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> tuple[MultiBlock, MultiBlock]: ...  # type: ignore[misc]
     @overload  # MultiBlock, return_clipped not known
-    def clip(  # type: ignore[misc]
-        self: MultiBlock,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> MultiBlock | tuple[MultiBlock, MultiBlock]: ...
+    def clip(self: MultiBlock, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> MultiBlock | tuple[MultiBlock, MultiBlock]: ...  # type: ignore[misc]
     @overload  # DataSet, return_clipped=False
-    def clip(  # type: ignore[misc]
-        self: DataSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> UnstructuredGrid: ...
+    def clip(self: DataSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: Literal[False] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
     @overload  # DataSet, return_clipped=True
-    def clip(  # type: ignore[misc]
-        self: DataSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: Literal[True] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip(self: DataSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: Literal[True] = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # DataSet, return_clipped not known
-    def clip(  # type: ignore[misc]
-        self: DataSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        inplace: Literal[False] = ...,
-        return_clipped: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip(self: DataSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., invert: bool = ..., value: float = ..., inplace: Literal[False] = ..., return_clipped: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['normal'])
     def clip(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3577,46 +3416,18 @@ class DataObjectFilters:
                 return self
         return result
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # PolyData
-    def clip_box(  # type: ignore[misc]
-        self: PolyData,
-        bounds: float | VectorLike[float] | PolyData | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        factor: float = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        merge_points: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> PolyData: ...
+    def clip_box(self: PolyData, bounds: float | VectorLike[float] | PolyData | None = ..., invert: bool = ..., factor: float = ..., progress_bar: bool = ..., merge_points: bool = ..., crinkle: bool = ...) -> PolyData: ...  # type: ignore[misc]
     @overload  # PointSet
-    def clip_box(  # type: ignore[misc]
-        self: PointSet,
-        bounds: float | VectorLike[float] | PolyData | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        factor: float = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        merge_points: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> PointSet: ...
+    def clip_box(self: PointSet, bounds: float | VectorLike[float] | PolyData | None = ..., invert: bool = ..., factor: float = ..., progress_bar: bool = ..., merge_points: bool = ..., crinkle: bool = ...) -> PointSet: ...  # type: ignore[misc]
     @overload  # MultiBlock
-    def clip_box(  # type: ignore[misc]
-        self: MultiBlock,
-        bounds: float | VectorLike[float] | PolyData | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        factor: float = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        merge_points: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> MultiBlock: ...
+    def clip_box(self: MultiBlock, bounds: float | VectorLike[float] | PolyData | None = ..., invert: bool = ..., factor: float = ..., progress_bar: bool = ..., merge_points: bool = ..., crinkle: bool = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # DataSet
-    def clip_box(  # type: ignore[misc]
-        self: DataSet,
-        bounds: float | VectorLike[float] | PolyData | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        factor: float = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        merge_points: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> UnstructuredGrid: ...
+    def clip_box(self: DataSet, bounds: float | VectorLike[float] | PolyData | None = ..., invert: bool = ..., factor: float = ..., progress_bar: bool = ..., merge_points: bool = ..., crinkle: bool = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['bounds'])
     def clip_box(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3813,54 +3624,18 @@ class DataObjectFilters:
         clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
         return _cast_output_to_match_input_type(clipped, self)
 
+    # fmt: off
+    # ruff: disable[E501]
     @overload  # PolyData
-    def clip_slab(  # type: ignore[misc]
-        self: PolyData,
-        thickness: float,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        *,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,
-        progress_bar: bool = ...,
-        crinkle: bool = ...,
-        plane: PolyData | None = ...,
-    ) -> PolyData: ...
+    def clip_slab(self: PolyData, thickness: float, normal: VectorLike[float] | _NormalsLiteral | None = ..., *, origin: VectorLike[float] | None = ..., invert: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PolyData: ...  # type: ignore[misc]
     @overload  # PointSet
-    def clip_slab(  # type: ignore[misc]
-        self: PointSet,
-        thickness: float,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        *,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,
-        progress_bar: bool = ...,
-        crinkle: bool = ...,
-        plane: PolyData | None = ...,
-    ) -> PointSet: ...
+    def clip_slab(self: PointSet, thickness: float, normal: VectorLike[float] | _NormalsLiteral | None = ..., *, origin: VectorLike[float] | None = ..., invert: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> PointSet: ...  # type: ignore[misc]
     @overload  # MultiBlock
-    def clip_slab(  # type: ignore[misc]
-        self: MultiBlock,
-        thickness: float,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        *,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,
-        progress_bar: bool = ...,
-        crinkle: bool = ...,
-        plane: PolyData | None = ...,
-    ) -> MultiBlock: ...
+    def clip_slab(self: MultiBlock, thickness: float, normal: VectorLike[float] | _NormalsLiteral | None = ..., *, origin: VectorLike[float] | None = ..., invert: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # DataSet
-    def clip_slab(  # type: ignore[misc]
-        self: DataSet,
-        thickness: float,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        *,
-        origin: VectorLike[float] | None = ...,
-        invert: bool = ...,
-        progress_bar: bool = ...,
-        crinkle: bool = ...,
-        plane: PolyData | None = ...,
-    ) -> UnstructuredGrid: ...
+    def clip_slab(self: DataSet, thickness: float, normal: VectorLike[float] | _NormalsLiteral | None = ..., *, origin: VectorLike[float] | None = ..., invert: bool = ..., progress_bar: bool = ..., crinkle: bool = ..., plane: PolyData | None = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
+    # ruff: enable[E501]
+    # fmt: on
     def clip_slab(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,
         thickness: float,
@@ -3989,22 +3764,14 @@ class DataObjectFilters:
         result = _cast_output_to_match_input_type(result, self)
         return _remove_unused_points_post_clip(result, input_bounds)
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # MultiBlock
-    def slice_implicit(  # type: ignore[misc]
-        self: MultiBlock,
-        implicit_function: _vtk.vtkImplicitFunction,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> MultiBlock: ...
+    def slice_implicit(self: MultiBlock, implicit_function: _vtk.vtkImplicitFunction, generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # DataSet
-    def slice_implicit(  # type: ignore[misc]
-        self: DataSet,
-        implicit_function: _vtk.vtkImplicitFunction,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> PolyData: ...
+    def slice_implicit(self: DataSet, implicit_function: _vtk.vtkImplicitFunction, generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ...) -> PolyData: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['implicit_function'])
     def slice_implicit(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -4106,26 +3873,14 @@ class DataObjectFilters:
             return output.contour()
         return output
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # MultiBlock
-    def slice(  # type: ignore[misc]
-        self: MultiBlock,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> MultiBlock: ...
+    def slice(self: MultiBlock, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ..., plane: PolyData | None = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # DataSet
-    def slice(  # type: ignore[misc]
-        self: DataSet,
-        normal: VectorLike[float] | _NormalsLiteral | None = ...,
-        origin: VectorLike[float] | None = ...,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        plane: PolyData | None = ...,
-    ) -> PolyData: ...
+    def slice(self: DataSet, normal: VectorLike[float] | _NormalsLiteral | None = ..., origin: VectorLike[float] | None = ..., generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ..., plane: PolyData | None = ...) -> PolyData: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['normal'])
     def slice(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -4543,22 +4298,14 @@ class DataObjectFilters:
             output.append(slc, f'slice{i}')
         return output
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # MultiBlock
-    def slice_along_line(  # type: ignore[misc]
-        self: MultiBlock,
-        line: PolyData,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> MultiBlock: ...
+    def slice_along_line(self: MultiBlock, line: PolyData, generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ...) -> MultiBlock: ...  # type: ignore[misc]
     @overload  # DataSet
-    def slice_along_line(  # type: ignore[misc]
-        self: DataSet,
-        line: PolyData,
-        generate_triangles: bool = ...,  # noqa: FBT001
-        contour: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> PolyData: ...
+    def slice_along_line(self: DataSet, line: PolyData, generate_triangles: bool = ..., contour: bool = ..., progress_bar: bool = ...) -> PolyData: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['line'])
     def slice_along_line(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3245,7 +3245,7 @@ class DataObjectFilters:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
         return _maybe_cast_to_point_set(clipped)
 
-    @overload
+    @overload  # PolyData, return_clipped=False
     def clip(  # type: ignore[misc]
         self: PolyData,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3253,12 +3253,12 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = False,  # noqa: FBT002
+        return_clipped: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> PolyData: ...
-    @overload
+    @overload  # PolyData, return_clipped=True
     def clip(  # type: ignore[misc]
         self: PolyData,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3266,12 +3266,25 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = True,  # noqa: FBT002
+        return_clipped: Literal[True] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> tuple[PolyData, PolyData]: ...
-    @overload
+    @overload  # PolyData, return_clipped not known
+    def clip(  # type: ignore[misc]
+        self: PolyData,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> PolyData | tuple[PolyData, PolyData]: ...
+    @overload  # PointSet, return_clipped=False
     def clip(  # type: ignore[misc]
         self: PointSet,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3279,12 +3292,12 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = False,  # noqa: FBT002
+        return_clipped: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> PointSet: ...
-    @overload
+    @overload  # PointSet, return_clipped=True
     def clip(  # type: ignore[misc]
         self: PointSet,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3292,12 +3305,25 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = True,  # noqa: FBT002
+        return_clipped: Literal[True] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> tuple[PointSet, PointSet]: ...
-    @overload
+    @overload  # PointSet, return_clipped not known
+    def clip(  # type: ignore[misc]
+        self: PointSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> PointSet | tuple[PointSet, PointSet]: ...
+    @overload  # UnstructuredGrid, return_clipped=False
     def clip(  # type: ignore[misc]
         self: UnstructuredGrid,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3305,12 +3331,12 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[False] = False,  # noqa: FBT002
+        return_clipped: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> UnstructuredGrid: ...
-    @overload
+    @overload  # UnstructuredGrid, return_clipped=True
     def clip(  # type: ignore[misc]
         self: UnstructuredGrid,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3318,12 +3344,25 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: bool = ...,  # noqa: FBT001
-        return_clipped: Literal[True] = True,  # noqa: FBT002
+        return_clipped: Literal[True] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
-    @overload
+    @overload  # UnstructuredGrid, return_clipped not known
+    def clip(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        return_clipped: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload  # MultiBlock, return_clipped=False
     def clip(  # type: ignore[misc]
         self: MultiBlock,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3331,12 +3370,12 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: Literal[False] = ...,
-        return_clipped: Literal[False] = False,  # noqa: FBT002
+        return_clipped: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> MultiBlock: ...
-    @overload
+    @overload  # MultiBlock, return_clipped=True
     def clip(  # type: ignore[misc]
         self: MultiBlock,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3344,12 +3383,25 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: Literal[False] = ...,
-        return_clipped: Literal[True] = True,  # noqa: FBT002
+        return_clipped: Literal[True] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> tuple[MultiBlock, MultiBlock]: ...
-    @overload
+    @overload  # MultiBlock, return_clipped not known
+    def clip(  # type: ignore[misc]
+        self: MultiBlock,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> MultiBlock | tuple[MultiBlock, MultiBlock]: ...
+    @overload  # DataSet, return_clipped=False
     def clip(  # type: ignore[misc]
         self: DataSet,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3357,12 +3409,12 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: Literal[False] = ...,
-        return_clipped: Literal[False] = False,  # noqa: FBT002
+        return_clipped: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> UnstructuredGrid: ...
-    @overload
+    @overload  # DataSet, return_clipped=True
     def clip(  # type: ignore[misc]
         self: DataSet,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -3370,11 +3422,24 @@ class DataObjectFilters:
         invert: bool = ...,  # noqa: FBT001
         value: float = ...,
         inplace: Literal[False] = ...,
-        return_clipped: Literal[True] = True,  # noqa: FBT002
+        return_clipped: Literal[True] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload  # DataSet, return_clipped not known
+    def clip(  # type: ignore[misc]
+        self: DataSet,
+        normal: VectorLike[float] | _NormalsLiteral | None = ...,
+        origin: VectorLike[float] | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        inplace: Literal[False] = ...,
+        return_clipped: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+        plane: PolyData | None = ...,
+    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
     @_deprecate_positional_args(allowed=['normal'])
     def clip(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetOrMultiBlockType,
@@ -3512,7 +3577,17 @@ class DataObjectFilters:
                 return self
         return result
 
-    @overload
+    @overload  # PolyData
+    def clip_box(  # type: ignore[misc]
+        self: PolyData,
+        bounds: float | VectorLike[float] | PolyData | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        factor: float = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        merge_points: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> PolyData: ...
+    @overload  # PointSet
     def clip_box(  # type: ignore[misc]
         self: PointSet,
         bounds: float | VectorLike[float] | PolyData | None = ...,
@@ -3522,7 +3597,7 @@ class DataObjectFilters:
         merge_points: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
     ) -> PointSet: ...
-    @overload
+    @overload  # MultiBlock
     def clip_box(  # type: ignore[misc]
         self: MultiBlock,
         bounds: float | VectorLike[float] | PolyData | None = ...,
@@ -3532,7 +3607,7 @@ class DataObjectFilters:
         merge_points: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
     ) -> MultiBlock: ...
-    @overload
+    @overload  # DataSet
     def clip_box(  # type: ignore[misc]
         self: DataSet,
         bounds: float | VectorLike[float] | PolyData | None = ...,
@@ -3738,7 +3813,7 @@ class DataObjectFilters:
         clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
         return _cast_output_to_match_input_type(clipped, self)
 
-    @overload
+    @overload  # PolyData
     def clip_slab(  # type: ignore[misc]
         self: PolyData,
         thickness: float,
@@ -3750,7 +3825,7 @@ class DataObjectFilters:
         crinkle: bool = ...,
         plane: PolyData | None = ...,
     ) -> PolyData: ...
-    @overload
+    @overload  # PointSet
     def clip_slab(  # type: ignore[misc]
         self: PointSet,
         thickness: float,
@@ -3762,7 +3837,7 @@ class DataObjectFilters:
         crinkle: bool = ...,
         plane: PolyData | None = ...,
     ) -> PointSet: ...
-    @overload
+    @overload  # MultiBlock
     def clip_slab(  # type: ignore[misc]
         self: MultiBlock,
         thickness: float,
@@ -3774,7 +3849,7 @@ class DataObjectFilters:
         crinkle: bool = ...,
         plane: PolyData | None = ...,
     ) -> MultiBlock: ...
-    @overload
+    @overload  # DataSet
     def clip_slab(  # type: ignore[misc]
         self: DataSet,
         thickness: float,
@@ -3914,7 +3989,7 @@ class DataObjectFilters:
         result = _cast_output_to_match_input_type(result, self)
         return _remove_unused_points_post_clip(result, input_bounds)
 
-    @overload
+    @overload  # MultiBlock
     def slice_implicit(  # type: ignore[misc]
         self: MultiBlock,
         implicit_function: _vtk.vtkImplicitFunction,
@@ -3922,7 +3997,7 @@ class DataObjectFilters:
         contour: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
     ) -> MultiBlock: ...
-    @overload
+    @overload  # DataSet
     def slice_implicit(  # type: ignore[misc]
         self: DataSet,
         implicit_function: _vtk.vtkImplicitFunction,
@@ -4031,7 +4106,7 @@ class DataObjectFilters:
             return output.contour()
         return output
 
-    @overload
+    @overload  # MultiBlock
     def slice(  # type: ignore[misc]
         self: MultiBlock,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -4041,7 +4116,7 @@ class DataObjectFilters:
         progress_bar: bool = ...,  # noqa: FBT001
         plane: PolyData | None = ...,
     ) -> MultiBlock: ...
-    @overload
+    @overload  # DataSet
     def slice(  # type: ignore[misc]
         self: DataSet,
         normal: VectorLike[float] | _NormalsLiteral | None = ...,
@@ -4468,18 +4543,18 @@ class DataObjectFilters:
             output.append(slc, f'slice{i}')
         return output
 
-    @overload
+    @overload  # MultiBlock
     def slice_along_line(  # type: ignore[misc]
         self: MultiBlock,
-        line: pv.PolyData,
+        line: PolyData,
         generate_triangles: bool = ...,  # noqa: FBT001
         contour: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
     ) -> MultiBlock: ...
-    @overload
+    @overload  # DataSet
     def slice_along_line(  # type: ignore[misc]
         self: DataSet,
-        line: pv.PolyData,
+        line: PolyData,
         generate_triangles: bool = ...,  # noqa: FBT001
         contour: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -648,126 +648,34 @@ class DataSetFilters(DataObjectFilters):
         result.point_data['implicit_distance'] = pv.convert_array(dists)
         return result
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # PolyData, both=False
-    def clip_scalar(  # type: ignore[misc]
-        self: PolyData,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = ...,
-    ) -> PolyData: ...
+    def clip_scalar(self: PolyData, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[False] = ...) -> PolyData: ...  # type: ignore[misc]
     @overload  # PolyData, both=True
-    def clip_scalar(  # type: ignore[misc]
-        self: PolyData,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = ...,
-    ) -> tuple[PolyData, PolyData]: ...
+    def clip_scalar(self: PolyData, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[True] = ...) -> tuple[PolyData, PolyData]: ...  # type: ignore[misc]
     @overload  # PolyData, both not known
-    def clip_scalar(  # type: ignore[misc]
-        self: PolyData,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: bool = ...,  # noqa: FBT001
-    ) -> PolyData | tuple[PolyData, PolyData]: ...
+    def clip_scalar(self: PolyData, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: bool = ...) -> PolyData | tuple[PolyData, PolyData]: ...  # type: ignore[misc]
     @overload  # PointSet, both=False
-    def clip_scalar(  # type: ignore[misc]
-        self: PointSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = ...,
-    ) -> PointSet: ...
+    def clip_scalar(self: PointSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[False] = ...) -> PointSet: ...  # type: ignore[misc]
     @overload  # PointSet, both=True
-    def clip_scalar(  # type: ignore[misc]
-        self: PointSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = ...,
-    ) -> tuple[PointSet, PointSet]: ...
+    def clip_scalar(self: PointSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[True] = ...) -> tuple[PointSet, PointSet]: ...  # type: ignore[misc]
     @overload  # PointSet, both not known
-    def clip_scalar(  # type: ignore[misc]
-        self: PointSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: bool = ...,  # noqa: FBT001
-    ) -> PointSet | tuple[PointSet, PointSet]: ...
+    def clip_scalar(self: PointSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: bool = ...) -> PointSet | tuple[PointSet, PointSet]: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, both=False
-    def clip_scalar(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = ...,
-    ) -> UnstructuredGrid: ...
+    def clip_scalar(self: UnstructuredGrid, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[False] = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, both=True
-    def clip_scalar(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = ...,
-    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip_scalar(self: UnstructuredGrid, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: Literal[True] = ...) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # UnstructuredGrid, both not known
-    def clip_scalar(  # type: ignore[misc]
-        self: UnstructuredGrid,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: bool = ...,  # noqa: FBT001
-    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip_scalar(self: UnstructuredGrid, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: bool = ..., progress_bar: bool = ..., both: bool = ...) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # DataSet, both=False
-    def clip_scalar(  # type: ignore[misc]
-        self: DataSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = ...,
-    ) -> UnstructuredGrid: ...
+    def clip_scalar(self: DataSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: Literal[False] = ..., progress_bar: bool = ..., both: Literal[False] = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
     @overload  # DataSet, both=True
-    def clip_scalar(  # type: ignore[misc]
-        self: DataSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = ...,
-    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip_scalar(self: DataSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: Literal[False] = ..., progress_bar: bool = ..., both: Literal[True] = ...) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
     @overload  # DataSet, both not known
-    def clip_scalar(  # type: ignore[misc]
-        self: DataSet,
-        scalars: str | None = ...,
-        invert: bool = ...,  # noqa: FBT001
-        value: float | VectorLike[float] = ...,
-        inplace: Literal[False] = ...,
-        progress_bar: bool = ...,  # noqa: FBT001
-        both: bool = ...,  # noqa: FBT001
-    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    def clip_scalar(self: DataSet, scalars: str | None = ..., invert: bool = ..., value: float | VectorLike[float] = ..., inplace: Literal[False] = ..., progress_bar: bool = ..., both: bool = ...) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args
     def clip_scalar(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,
@@ -905,36 +813,16 @@ class DataSetFilters(DataObjectFilters):
             return result0, result1
         return result0
 
+    # fmt: off
+    # ruff: disable[E501, FBT001]
     @overload  # PolyData
-    def clip_surface(  # type: ignore[misc]
-        self: PolyData,
-        surface: DataSet | _vtk.vtkDataSet,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        compute_distance: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> PolyData: ...
+    def clip_surface(self: PolyData, surface: DataSet | _vtk.vtkDataSet, invert: bool = ..., value: float = ..., compute_distance: bool = ..., progress_bar: bool = ..., crinkle: bool = ...) -> PolyData: ...  # type: ignore[misc]
     @overload  # PointSet
-    def clip_surface(  # type: ignore[misc]
-        self: PointSet,
-        surface: DataSet | _vtk.vtkDataSet,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        compute_distance: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> PointSet: ...
+    def clip_surface(self: PointSet, surface: DataSet | _vtk.vtkDataSet, invert: bool = ..., value: float = ..., compute_distance: bool = ..., progress_bar: bool = ..., crinkle: bool = ...) -> PointSet: ...  # type: ignore[misc]
     @overload  # DataSet
-    def clip_surface(  # type: ignore[misc]
-        self: DataSet,
-        surface: DataSet | _vtk.vtkDataSet,
-        invert: bool = ...,  # noqa: FBT001
-        value: float = ...,
-        compute_distance: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        crinkle: bool = ...,  # noqa: FBT001
-    ) -> UnstructuredGrid: ...
+    def clip_surface(self: DataSet, surface: DataSet | _vtk.vtkDataSet, invert: bool = ..., value: float = ..., compute_distance: bool = ..., progress_bar: bool = ..., crinkle: bool = ...) -> UnstructuredGrid: ...  # type: ignore[misc]
+    # ruff: enable[E501, FBT001]
+    # fmt: on
     @_deprecate_positional_args(allowed=['surface'])
     def clip_surface(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -14,6 +14,7 @@ from typing import Literal
 from typing import NamedTuple
 from typing import cast
 from typing import get_args
+from typing import overload
 import warnings
 
 import numpy as np
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from pyvista import DataSet
     from pyvista import ImageData
     from pyvista import MultiBlock
+    from pyvista import PointSet
     from pyvista import PolyData
     from pyvista import RectilinearGrid
     from pyvista import UnstructuredGrid
@@ -646,6 +648,86 @@ class DataSetFilters(DataObjectFilters):
         result.point_data['implicit_distance'] = pv.convert_array(dists)
         return result
 
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: PolyData,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[False] = False,  # noqa: FBT002
+    ) -> PolyData: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: PolyData,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[True] = True,  # noqa: FBT002
+    ) -> tuple[PolyData, PolyData]: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: PointSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[False] = False,  # noqa: FBT002
+    ) -> PointSet: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: PointSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[True] = True,  # noqa: FBT002
+    ) -> tuple[PointSet, PointSet]: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[False] = False,  # noqa: FBT002
+    ) -> UnstructuredGrid: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[True] = True,  # noqa: FBT002
+    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: DataSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: Literal[False] = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[False] = False,  # noqa: FBT002
+    ) -> UnstructuredGrid: ...
+    @overload
+    def clip_scalar(  # type: ignore[misc]
+        self: DataSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: Literal[False] = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: Literal[True] = True,  # noqa: FBT002
+    ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
     @_deprecate_positional_args
     def clip_scalar(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,
@@ -783,6 +865,36 @@ class DataSetFilters(DataObjectFilters):
             return result0, result1
         return result0
 
+    @overload
+    def clip_surface(  # type: ignore[misc]
+        self: PolyData,
+        surface: DataSet | _vtk.vtkDataSet,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        compute_distance: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> PolyData: ...
+    @overload
+    def clip_surface(  # type: ignore[misc]
+        self: PointSet,
+        surface: DataSet | _vtk.vtkDataSet,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        compute_distance: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> PointSet: ...
+    @overload
+    def clip_surface(  # type: ignore[misc]
+        self: DataSet,
+        surface: DataSet | _vtk.vtkDataSet,
+        invert: bool = ...,  # noqa: FBT001
+        value: float = ...,
+        compute_distance: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        crinkle: bool = ...,  # noqa: FBT001
+    ) -> UnstructuredGrid: ...
     @_deprecate_positional_args(allowed=['surface'])
     def clip_surface(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -648,7 +648,7 @@ class DataSetFilters(DataObjectFilters):
         result.point_data['implicit_distance'] = pv.convert_array(dists)
         return result
 
-    @overload
+    @overload  # PolyData, both=False
     def clip_scalar(  # type: ignore[misc]
         self: PolyData,
         scalars: str | None = ...,
@@ -656,9 +656,9 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = False,  # noqa: FBT002
+        both: Literal[False] = ...,
     ) -> PolyData: ...
-    @overload
+    @overload  # PolyData, both=True
     def clip_scalar(  # type: ignore[misc]
         self: PolyData,
         scalars: str | None = ...,
@@ -666,9 +666,19 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = True,  # noqa: FBT002
+        both: Literal[True] = ...,
     ) -> tuple[PolyData, PolyData]: ...
-    @overload
+    @overload  # PolyData, both not known
+    def clip_scalar(  # type: ignore[misc]
+        self: PolyData,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: bool = ...,  # noqa: FBT001
+    ) -> PolyData | tuple[PolyData, PolyData]: ...
+    @overload  # PointSet, both=False
     def clip_scalar(  # type: ignore[misc]
         self: PointSet,
         scalars: str | None = ...,
@@ -676,9 +686,9 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = False,  # noqa: FBT002
+        both: Literal[False] = ...,
     ) -> PointSet: ...
-    @overload
+    @overload  # PointSet, both=True
     def clip_scalar(  # type: ignore[misc]
         self: PointSet,
         scalars: str | None = ...,
@@ -686,9 +696,19 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = True,  # noqa: FBT002
+        both: Literal[True] = ...,
     ) -> tuple[PointSet, PointSet]: ...
-    @overload
+    @overload  # PointSet, both not known
+    def clip_scalar(  # type: ignore[misc]
+        self: PointSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: bool = ...,  # noqa: FBT001
+    ) -> PointSet | tuple[PointSet, PointSet]: ...
+    @overload  # UnstructuredGrid, both=False
     def clip_scalar(  # type: ignore[misc]
         self: UnstructuredGrid,
         scalars: str | None = ...,
@@ -696,9 +716,9 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = False,  # noqa: FBT002
+        both: Literal[False] = ...,
     ) -> UnstructuredGrid: ...
-    @overload
+    @overload  # UnstructuredGrid, both=True
     def clip_scalar(  # type: ignore[misc]
         self: UnstructuredGrid,
         scalars: str | None = ...,
@@ -706,9 +726,19 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: bool = ...,  # noqa: FBT001
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = True,  # noqa: FBT002
+        both: Literal[True] = ...,
     ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
-    @overload
+    @overload  # UnstructuredGrid, both not known
+    def clip_scalar(  # type: ignore[misc]
+        self: UnstructuredGrid,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: bool = ...,  # noqa: FBT001
+    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload  # DataSet, both=False
     def clip_scalar(  # type: ignore[misc]
         self: DataSet,
         scalars: str | None = ...,
@@ -716,9 +746,9 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[False] = False,  # noqa: FBT002
+        both: Literal[False] = ...,
     ) -> UnstructuredGrid: ...
-    @overload
+    @overload  # DataSet, both=True
     def clip_scalar(  # type: ignore[misc]
         self: DataSet,
         scalars: str | None = ...,
@@ -726,8 +756,18 @@ class DataSetFilters(DataObjectFilters):
         value: float | VectorLike[float] = ...,
         inplace: Literal[False] = ...,
         progress_bar: bool = ...,  # noqa: FBT001
-        both: Literal[True] = True,  # noqa: FBT002
+        both: Literal[True] = ...,
     ) -> tuple[UnstructuredGrid, UnstructuredGrid]: ...
+    @overload  # DataSet, both not known
+    def clip_scalar(  # type: ignore[misc]
+        self: DataSet,
+        scalars: str | None = ...,
+        invert: bool = ...,  # noqa: FBT001
+        value: float | VectorLike[float] = ...,
+        inplace: Literal[False] = ...,
+        progress_bar: bool = ...,  # noqa: FBT001
+        both: bool = ...,  # noqa: FBT001
+    ) -> UnstructuredGrid | tuple[UnstructuredGrid, UnstructuredGrid]: ...
     @_deprecate_positional_args
     def clip_scalar(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,
@@ -865,7 +905,7 @@ class DataSetFilters(DataObjectFilters):
             return result0, result1
         return result0
 
-    @overload
+    @overload  # PolyData
     def clip_surface(  # type: ignore[misc]
         self: PolyData,
         surface: DataSet | _vtk.vtkDataSet,
@@ -875,7 +915,7 @@ class DataSetFilters(DataObjectFilters):
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
     ) -> PolyData: ...
-    @overload
+    @overload  # PointSet
     def clip_surface(  # type: ignore[misc]
         self: PointSet,
         surface: DataSet | _vtk.vtkDataSet,
@@ -885,7 +925,7 @@ class DataSetFilters(DataObjectFilters):
         progress_bar: bool = ...,  # noqa: FBT001
         crinkle: bool = ...,  # noqa: FBT001
     ) -> PointSet: ...
-    @overload
+    @overload  # DataSet
     def clip_surface(  # type: ignore[misc]
         self: DataSet,
         surface: DataSet | _vtk.vtkDataSet,

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2066,7 +2066,7 @@ class PolyDataFilters(DataSetFilters):
         inplace: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
         plane: PolyData | None = None,
-    ):
+    ) -> PolyData:
         """Clip a closed polydata surface with a plane.
 
         The origin and normal may be set explicitly or implicitly using a

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import textwrap
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import NoReturn
 from typing import cast
 
 import numpy as np
@@ -459,23 +460,23 @@ class PointSet(_PointSetBase, _vtk.vtkPointSet):
         """Raise cell operations are not supported."""
         raise PointSetCellOperationError
 
-    def slice(self, *args, **kwargs):  # noqa: ARG002  # numpydoc ignore=PR01
+    def slice(self, *args, **kwargs) -> NoReturn:  # noqa: ARG002  # numpydoc ignore=PR01
         """Raise dimension reducing operations are not supported."""
         raise PointSetDimensionReductionError
 
-    def slice_along_axis(self, *args, **kwargs):  # noqa: ARG002  # numpydoc ignore=PR01
+    def slice_along_axis(self, *args, **kwargs) -> NoReturn:  # noqa: ARG002  # numpydoc ignore=PR01
         """Raise dimension reducing operations are not supported."""
         raise PointSetDimensionReductionError
 
-    def slice_along_line(self, *args, **kwargs):  # noqa: ARG002  # numpydoc ignore=PR01
+    def slice_along_line(self, *args, **kwargs) -> NoReturn:  # noqa: ARG002  # numpydoc ignore=PR01
         """Raise dimension reducing operations are not supported."""
         raise PointSetDimensionReductionError
 
-    def slice_implicit(self, *args, **kwargs):  # noqa: ARG002  # numpydoc ignore=PR01
+    def slice_implicit(self, *args, **kwargs) -> NoReturn:  # noqa: ARG002  # numpydoc ignore=PR01
         """Raise dimension reducing operations are not supported."""
         raise PointSetDimensionReductionError
 
-    def slice_orthogonal(self, *args, **kwargs):  # noqa: ARG002  # numpydoc ignore=PR01
+    def slice_orthogonal(self, *args, **kwargs) -> NoReturn:  # noqa: ARG002  # numpydoc ignore=PR01
         """Raise dimension reducing operations are not supported."""
         raise PointSetDimensionReductionError
 

--- a/tests/typing/cases/clip_slice_filters.py
+++ b/tests/typing/cases/clip_slice_filters.py
@@ -1,8 +1,8 @@
 """Typing cases for the clip and slice filters.
 
 Which class each filter gives back is checked at runtime in
-``tests/core/test_dataobject_filters.py``; these cases hold what a type checker
-infers from the same calls, including the tuple shapes that table cannot express.
+``tests/core/test_dataobject_filters.py`` and ``tests/core/test_dataset_filters.py``;
+these cases hold what a type checker infers from the same calls, one per overload.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from type_assert import assert_types
 
 import pyvista as pv
 from pyvista import _vtk
+from pyvista.core.utilities import generate_plane
 
 
 def poly() -> pv.PolyData:
@@ -66,6 +67,13 @@ def image_with_scalars() -> pv.ImageData:
     return mesh
 
 
+def pointset_with_scalars() -> pv.PointSet:
+    """Return a point cloud carrying point scalars."""
+    mesh = pointset()
+    mesh.point_data['data'] = mesh.points[:, 2]
+    return mesh
+
+
 def unstructured_with_scalars() -> pv.UnstructuredGrid:
     """Return an unstructured grid carrying point scalars."""
     mesh = unstructured()
@@ -73,12 +81,21 @@ def unstructured_with_scalars() -> pv.UnstructuredGrid:
     return mesh
 
 
+def explicit_structured() -> pv.ExplicitStructuredGrid:
+    """Return a small explicit structured grid, which is not an UnstructuredGrid."""
+    grid = structured()
+    grid.dimensions = [5, 5, 5]
+    return grid.cast_to_explicit_structured_grid()
+
+
 def a_plane() -> _vtk.vtkPlane:
     """Return a plane through the origin."""
-    plane = _vtk.vtkPlane()
-    plane.SetOrigin(0.0, 0.0, 0.0)
-    plane.SetNormal(1.0, 0.0, 0.0)
-    return plane
+    return generate_plane((1.0, 0.0, 0.0), (0.0, 0.0, 0.0))
+
+
+def a_flag() -> bool:
+    """Return a flag typed only as ``bool``, so the widened overloads apply."""
+    return True
 
 
 def a_line() -> pv.PolyData:
@@ -93,48 +110,60 @@ def a_surface() -> pv.PolyData:
 
 # A plane clip keeps a surface a surface and a point cloud a point cloud
 assert_types(poly().clip(), pv.PolyData)
-assert_types(poly().clip(normal='z'), pv.PolyData)
-assert_types(poly().clip(crinkle=True), pv.PolyData)
-assert_types(poly().clip(inplace=True), pv.PolyData)
 assert_types(pointset().clip(), pv.PointSet)
-assert_types(pointset().clip(inplace=True), pv.PointSet)
 assert_types(unstructured().clip(), pv.UnstructuredGrid)
-assert_types(unstructured().clip(inplace=True), pv.UnstructuredGrid)
 assert_types(image().clip(), pv.UnstructuredGrid)
-assert_types(rectilinear().clip(), pv.UnstructuredGrid)
-assert_types(structured().clip(), pv.UnstructuredGrid)
 assert_types(multiblock().clip(), pv.MultiBlock)
+# An ExplicitStructuredGrid is not an UnstructuredGrid, so it takes the DataSet overload
+assert_types(explicit_structured().clip(), pv.UnstructuredGrid)
 
 # `return_clipped` hands back both halves, of the same class
-assert_types(poly().clip(return_clipped=False), pv.PolyData)
 assert_types(poly().clip(return_clipped=True), tuple[pv.PolyData, pv.PolyData])
 assert_types(pointset().clip(return_clipped=True), tuple[pv.PointSet, pv.PointSet])
+assert_types(unstructured().clip(return_clipped=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
 assert_types(image().clip(return_clipped=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
 assert_types(multiblock().clip(return_clipped=True), tuple[pv.MultiBlock, pv.MultiBlock])
 
-# A box clip tetrahedralizes a surface, and clips a point cloud through its vertices
-assert_types(poly().clip_box(), pv.UnstructuredGrid)
+# A flag the caller computed gives both halves as one union
+assert_types(poly().clip(return_clipped=a_flag()), pv.PolyData | tuple[pv.PolyData, pv.PolyData])
+assert_types(pointset().clip(return_clipped=a_flag()), pv.PointSet | tuple[pv.PointSet, pv.PointSet])
+assert_types(unstructured().clip(return_clipped=a_flag()), pv.UnstructuredGrid | tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
+assert_types(image().clip(return_clipped=a_flag()), pv.UnstructuredGrid | tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
+assert_types(multiblock().clip(return_clipped=a_flag()), pv.MultiBlock | tuple[pv.MultiBlock, pv.MultiBlock])
+
+# Only the classes a clip can be copied back into accept `inplace`
+assert_types(poly().clip(inplace=True), pv.PolyData)
+assert_types(pointset().clip(inplace=True), pv.PointSet)
+assert_types(unstructured().clip(inplace=True), pv.UnstructuredGrid)
+
+# A box clip splits the cells it cuts, and clips a point cloud through its vertices
+assert_types(poly().clip_box(), pv.PolyData)
 assert_types(pointset().clip_box(), pv.PointSet)
 assert_types(image().clip_box(), pv.UnstructuredGrid)
-assert_types(unstructured().clip_box(merge_points=False), pv.UnstructuredGrid)
 assert_types(multiblock().clip_box(), pv.MultiBlock)
 
 # A slab clip follows the plane clip
 assert_types(poly().clip_slab(thickness=0.2, normal='z'), pv.PolyData)
 assert_types(pointset().clip_slab(thickness=0.2, normal='z'), pv.PointSet)
 assert_types(image().clip_slab(thickness=0.2, normal='z'), pv.UnstructuredGrid)
-assert_types(unstructured().clip_slab(thickness=0.2, normal='z'), pv.UnstructuredGrid)
 assert_types(multiblock().clip_slab(thickness=0.2, normal='z'), pv.MultiBlock)
 
-# Clipping by scalars or by a surface takes a dataset, never a composite
+# Clipping by scalars follows the input class, and `both` hands back both halves
 assert_types(poly_with_scalars().clip_scalar(value=0.0), pv.PolyData)
 assert_types(poly_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.PolyData, pv.PolyData])
 assert_types(poly_with_scalars().clip_scalar(value=0.0, inplace=True), pv.PolyData)
-assert_types(image_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
+assert_types(pointset_with_scalars().clip_scalar(value=0.0), pv.PointSet)
+assert_types(pointset_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.PointSet, pv.PointSet])
+assert_types(unstructured_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
 assert_types(
     unstructured_with_scalars().clip_scalar(value=0.0, both=True),
     tuple[pv.UnstructuredGrid, pv.UnstructuredGrid],
 )
+assert_types(image_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
+assert_types(image_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
+assert_types(poly_with_scalars().clip_scalar(value=0.0, both=a_flag()), pv.PolyData | tuple[pv.PolyData, pv.PolyData])
+
+# Clipping by a surface follows the input class too
 assert_types(poly().clip_surface(a_surface()), pv.PolyData)
 assert_types(pointset().clip_surface(a_surface()), pv.PointSet)
 assert_types(image().clip_surface(a_surface()), pv.UnstructuredGrid)
@@ -143,9 +172,6 @@ assert_types(poly().clip_closed_surface(), pv.PolyData)
 # Slicing reduces any dataset to a surface, and a composite stays a composite
 assert_types(poly().slice(), pv.PolyData)
 assert_types(image().slice(), pv.PolyData)
-assert_types(rectilinear().slice(), pv.PolyData)
-assert_types(structured().slice(), pv.PolyData)
-assert_types(unstructured().slice(), pv.PolyData)
 assert_types(multiblock().slice(), pv.MultiBlock)
 assert_types(image().slice_implicit(a_plane()), pv.PolyData)
 assert_types(multiblock().slice_implicit(a_plane()), pv.MultiBlock)
@@ -153,7 +179,6 @@ assert_types(image().slice_along_line(a_line()), pv.PolyData)
 assert_types(multiblock().slice_along_line(a_line()), pv.MultiBlock)
 
 # These two collect their slices into a composite, whatever went in
-assert_types(poly().slice_orthogonal(), pv.MultiBlock)
 assert_types(image().slice_orthogonal(), pv.MultiBlock)
 assert_types(multiblock().slice_orthogonal(), pv.MultiBlock)
 assert_types(image().slice_along_axis(n=2), pv.MultiBlock)

--- a/tests/typing/cases/clip_slice_filters.py
+++ b/tests/typing/cases/clip_slice_filters.py
@@ -1,0 +1,160 @@
+"""Typing cases for the clip and slice filters.
+
+Which class each filter gives back is checked at runtime in
+``tests/core/test_dataobject_filters.py``; these cases hold what a type checker
+infers from the same calls, including the tuple shapes that table cannot express.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from type_assert import assert_types
+
+import pyvista as pv
+from pyvista import _vtk
+
+
+def poly() -> pv.PolyData:
+    """Return a sphere."""
+    return pv.Sphere(theta_resolution=8, phi_resolution=8)
+
+
+def pointset() -> pv.PointSet:
+    """Return a point cloud."""
+    return pv.PointSet(poly().points)
+
+
+def image() -> pv.ImageData:
+    """Return a small uniform grid."""
+    return pv.ImageData(dimensions=(5, 5, 5), spacing=(0.25, 0.25, 0.25), origin=(-0.5, -0.5, -0.5))
+
+
+def rectilinear() -> pv.RectilinearGrid:
+    """Return a small rectilinear grid."""
+    axis = np.linspace(-0.5, 0.5, 5)
+    return pv.RectilinearGrid(axis, axis, axis)
+
+
+def structured() -> pv.StructuredGrid:
+    """Return a small structured grid."""
+    axis = np.linspace(-0.5, 0.5, 5)
+    x, y, z = np.meshgrid(axis, axis, axis, indexing='ij')
+    return pv.StructuredGrid(x, y, z)
+
+
+def unstructured() -> pv.UnstructuredGrid:
+    """Return a small unstructured grid."""
+    return image().cast_to_unstructured_grid()
+
+
+def multiblock() -> pv.MultiBlock:
+    """Return a composite of two meshes."""
+    return pv.MultiBlock([poly(), image()])
+
+
+def poly_with_scalars() -> pv.PolyData:
+    """Return a sphere carrying point scalars."""
+    mesh = poly()
+    mesh.point_data['data'] = mesh.points[:, 2]
+    return mesh
+
+
+def image_with_scalars() -> pv.ImageData:
+    """Return a uniform grid carrying point scalars."""
+    mesh = image()
+    mesh.point_data['data'] = np.linspace(0.0, 1.0, mesh.n_points)
+    return mesh
+
+
+def unstructured_with_scalars() -> pv.UnstructuredGrid:
+    """Return an unstructured grid carrying point scalars."""
+    mesh = unstructured()
+    mesh.point_data['data'] = np.linspace(0.0, 1.0, mesh.n_points)
+    return mesh
+
+
+def a_plane() -> _vtk.vtkPlane:
+    """Return a plane through the origin."""
+    plane = _vtk.vtkPlane()
+    plane.SetOrigin(0.0, 0.0, 0.0)
+    plane.SetNormal(1.0, 0.0, 0.0)
+    return plane
+
+
+def a_line() -> pv.PolyData:
+    """Return a polyline crossing the test meshes."""
+    return pv.Line((-2.0, -2.0, -2.0), (2.0, 2.0, 2.0), resolution=4)
+
+
+def a_surface() -> pv.PolyData:
+    """Return a closed surface enclosing the test meshes."""
+    return pv.Sphere(radius=2.0, theta_resolution=8, phi_resolution=8)
+
+
+# A plane clip keeps a surface a surface and a point cloud a point cloud
+assert_types(poly().clip(), pv.PolyData)
+assert_types(poly().clip(normal='z'), pv.PolyData)
+assert_types(poly().clip(crinkle=True), pv.PolyData)
+assert_types(poly().clip(inplace=True), pv.PolyData)
+assert_types(pointset().clip(), pv.PointSet)
+assert_types(pointset().clip(inplace=True), pv.PointSet)
+assert_types(unstructured().clip(), pv.UnstructuredGrid)
+assert_types(unstructured().clip(inplace=True), pv.UnstructuredGrid)
+assert_types(image().clip(), pv.UnstructuredGrid)
+assert_types(rectilinear().clip(), pv.UnstructuredGrid)
+assert_types(structured().clip(), pv.UnstructuredGrid)
+assert_types(multiblock().clip(), pv.MultiBlock)
+
+# `return_clipped` hands back both halves, of the same class
+assert_types(poly().clip(return_clipped=False), pv.PolyData)
+assert_types(poly().clip(return_clipped=True), tuple[pv.PolyData, pv.PolyData])
+assert_types(pointset().clip(return_clipped=True), tuple[pv.PointSet, pv.PointSet])
+assert_types(image().clip(return_clipped=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
+assert_types(multiblock().clip(return_clipped=True), tuple[pv.MultiBlock, pv.MultiBlock])
+
+# A box clip tetrahedralizes a surface, and clips a point cloud through its vertices
+assert_types(poly().clip_box(), pv.UnstructuredGrid)
+assert_types(pointset().clip_box(), pv.PointSet)
+assert_types(image().clip_box(), pv.UnstructuredGrid)
+assert_types(unstructured().clip_box(merge_points=False), pv.UnstructuredGrid)
+assert_types(multiblock().clip_box(), pv.MultiBlock)
+
+# A slab clip follows the plane clip
+assert_types(poly().clip_slab(thickness=0.2, normal='z'), pv.PolyData)
+assert_types(pointset().clip_slab(thickness=0.2, normal='z'), pv.PointSet)
+assert_types(image().clip_slab(thickness=0.2, normal='z'), pv.UnstructuredGrid)
+assert_types(unstructured().clip_slab(thickness=0.2, normal='z'), pv.UnstructuredGrid)
+assert_types(multiblock().clip_slab(thickness=0.2, normal='z'), pv.MultiBlock)
+
+# Clipping by scalars or by a surface takes a dataset, never a composite
+assert_types(poly_with_scalars().clip_scalar(value=0.0), pv.PolyData)
+assert_types(poly_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.PolyData, pv.PolyData])
+assert_types(poly_with_scalars().clip_scalar(value=0.0, inplace=True), pv.PolyData)
+assert_types(image_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
+assert_types(
+    unstructured_with_scalars().clip_scalar(value=0.0, both=True),
+    tuple[pv.UnstructuredGrid, pv.UnstructuredGrid],
+)
+assert_types(poly().clip_surface(a_surface()), pv.PolyData)
+assert_types(pointset().clip_surface(a_surface()), pv.PointSet)
+assert_types(image().clip_surface(a_surface()), pv.UnstructuredGrid)
+assert_types(poly().clip_closed_surface(), pv.PolyData)
+
+# Slicing reduces any dataset to a surface, and a composite stays a composite
+assert_types(poly().slice(), pv.PolyData)
+assert_types(image().slice(), pv.PolyData)
+assert_types(rectilinear().slice(), pv.PolyData)
+assert_types(structured().slice(), pv.PolyData)
+assert_types(unstructured().slice(), pv.PolyData)
+assert_types(multiblock().slice(), pv.MultiBlock)
+assert_types(image().slice_implicit(a_plane()), pv.PolyData)
+assert_types(multiblock().slice_implicit(a_plane()), pv.MultiBlock)
+assert_types(image().slice_along_line(a_line()), pv.PolyData)
+assert_types(multiblock().slice_along_line(a_line()), pv.MultiBlock)
+
+# These two collect their slices into a composite, whatever went in
+assert_types(poly().slice_orthogonal(), pv.MultiBlock)
+assert_types(image().slice_orthogonal(), pv.MultiBlock)
+assert_types(multiblock().slice_orthogonal(), pv.MultiBlock)
+assert_types(image().slice_along_axis(n=2), pv.MultiBlock)
+assert_types(multiblock().slice_along_axis(n=2), pv.MultiBlock)

--- a/tests/typing/cases/clip_slice_filters.py
+++ b/tests/typing/cases/clip_slice_filters.py
@@ -30,12 +30,6 @@ def image() -> pv.ImageData:
     return pv.ImageData(dimensions=(5, 5, 5), spacing=(0.25, 0.25, 0.25), origin=(-0.5, -0.5, -0.5))
 
 
-def rectilinear() -> pv.RectilinearGrid:
-    """Return a small rectilinear grid."""
-    axis = np.linspace(-0.5, 0.5, 5)
-    return pv.RectilinearGrid(axis, axis, axis)
-
-
 def structured() -> pv.StructuredGrid:
     """Return a small structured grid."""
     axis = np.linspace(-0.5, 0.5, 5)

--- a/tests/typing/cases/clip_slice_filters.py
+++ b/tests/typing/cases/clip_slice_filters.py
@@ -155,10 +155,7 @@ assert_types(poly_with_scalars().clip_scalar(value=0.0, inplace=True), pv.PolyDa
 assert_types(pointset_with_scalars().clip_scalar(value=0.0), pv.PointSet)
 assert_types(pointset_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.PointSet, pv.PointSet])
 assert_types(unstructured_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
-assert_types(
-    unstructured_with_scalars().clip_scalar(value=0.0, both=True),
-    tuple[pv.UnstructuredGrid, pv.UnstructuredGrid],
-)
+assert_types(unstructured_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
 assert_types(image_with_scalars().clip_scalar(value=0.0), pv.UnstructuredGrid)
 assert_types(image_with_scalars().clip_scalar(value=0.0, both=True), tuple[pv.UnstructuredGrid, pv.UnstructuredGrid])
 assert_types(poly_with_scalars().clip_scalar(value=0.0, both=a_flag()), pv.PolyData | tuple[pv.PolyData, pv.PolyData])


### PR DESCRIPTION
Stacked on #9130, which made these filters' output type deliberate. Now that every clip keeps a `PolyData` a `PolyData` and a `PointSet` a `PointSet`, every slice gives a `PolyData`, and a composite carries the same rule into its blocks, the return type follows from the input class and can be written down.

Each clip and slice filter gets an overload per input class in place of the implicit `Any`, and 104 typing cases hold every answer. This supersedes the clip and slice part of #9123, which annotated the filters as they behaved before the fixes.

| Filter | `PolyData` | `PointSet` | Other datasets | `MultiBlock` |
| --- | --- | --- | --- | --- |
| `clip`, `clip_box`, `clip_slab`, `clip_surface`, `clip_scalar` | `PolyData` | `PointSet` | `UnstructuredGrid` | `MultiBlock` |
| `slice`, `slice_implicit`, `slice_along_line` | `PolyData` | — | `PolyData` | `MultiBlock` |
| `slice_orthogonal`, `slice_along_axis` | `MultiBlock` | — | `MultiBlock` | `MultiBlock` |

`return_clipped` and `both` give a tuple of the same class, and a widened variant per class keeps a computed flag callable, as `MultiBlock.recursive_iterator` already does. `inplace=True` is refused for the classes whose clipped output cannot be copied back into them, which #9130 made a clear `TypeError`; the case files cannot assert a rejected call, so that half rests on mypy over the package and on `test_clip_inplace_raises`. `PointSet`'s five slice guards return `NoReturn`.

Each stub sits on one line inside a `# fmt: off` / `# ruff: disable[E501, FBT001, FBT002]` region, so an overload block reads as a list of signatures rather than 12 lines apiece; the typing cases read the same way, which `tests/typing/cases/ruff.toml` already allowed for.

One call site the new types caught: `_clip_by_box_planes` passed `return_clipped` a runtime bool, so once `clip` is typed per that argument there is no overload to select. It branches around the two calls instead, which is what the loop already did a line later to unpack.

The cases assert what a type checker infers; the runtime classes are covered by the table in `tests/core/test_dataobject_filters.py` that #9130 adds, which also holds the counts, arrays and empty blocks a type cannot express.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
