### PR TITLE
Forward `pv.read` keyword arguments to registered readers

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -142,7 +142,7 @@ of PyVista's reader machinery the format gets:
      - no
      - yes
    * - Keyword arguments to :func:`pyvista.read`
-     - dropped
+     - forwarded as ``handler(path, **kwargs)``
      - set as reader attributes
    * - ``progress_bar=True``, ``validate=``
      - ignored
@@ -211,6 +211,14 @@ This is the entry-point equivalent of ``override=True`` on
 :func:`pyvista.register_reader`.  Both groups accept both forms, a
 callable or a :class:`pyvista.BaseReader` subclass.
 
+A callable override is the one case where :func:`pyvista.read` does not
+forward its keyword arguments.  For an extension PyVista ships a reader
+for, those arguments name attributes of *that* reader, so
+``progress_bar``, ``validate`` and any keyword argument route the read
+past the override to the built-in rather than being reinterpreted by the
+callable.  Register a :class:`pyvista.BaseReader` subclass to expose
+options on an extension PyVista already reads.
+
 Declaring an override for an extension PyVista does *not* currently
 read is allowed and silent.  It costs nothing and keeps the package
 working if a later PyVista release adds a reader for that extension.
@@ -236,10 +244,12 @@ built-in format reads differently than expected.
 
 When :func:`pyvista.read` is given a remote URI (``https://``,
 ``s3://``, etc.) and a custom reader is registered for the file
-extension, the URI is passed directly to the reader.  If the reader
-raises :class:`~pyvista.LocalFileRequiredError`, PyVista downloads
-the file to a temporary local path and retries.  For built-in
-formats with no custom reader, the download happens automatically.
+extension, the URI is passed directly to the reader along with any
+keyword arguments.  If the reader raises
+:class:`~pyvista.LocalFileRequiredError`, PyVista downloads the file to
+a temporary local path and retries.  For built-in formats with no custom
+reader, and for a callable override handed reader arguments, the
+download happens automatically.
 This uses ``fsspec`` when available (install with
 ``pip install pyvista[io]``), falling back to ``pooch`` for HTTP(S)
 URIs.

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -394,6 +394,13 @@ def read(  # noqa: PLR0917
                 setattr(reader, key, value)
             mesh = reader.read()
 
+        When the extension resolves to a callable registered with
+        :func:`pyvista.register_reader`, ``**kwargs`` is forwarded to that
+        callable as ``handler(path, **kwargs)`` instead. ``progress_bar`` and
+        ``validate`` are never forwarded, and a callable that overrides an
+        extension PyVista already reads is bypassed entirely so that these
+        arguments keep naming attributes of the built-in reader.
+
         .. versionadded:: 0.49
 
     Returns
@@ -452,10 +459,12 @@ def read(  # noqa: PLR0917
 def _needs_reader_object(
     ext: str, *, progress_bar: bool, validate: bool | None, kwargs: dict[str, Any]
 ) -> bool:
-    """Return ``True`` when the caller asked for what only a reader object provides.
+    """Return ``True`` when the caller asked for something a handler cannot serve.
 
-    A handler takes a path and nothing else, so an override of a built-in
-    extension steps aside rather than dropping arguments it cannot honor.
+    ``progress_bar`` and ``validate`` are reader-object features, and for a
+    built-in extension ``kwargs`` name attributes of the built-in reader. An
+    override of such an extension therefore steps aside rather than
+    reinterpreting any of the three.
     """
     from pyvista.core.utilities.reader import CLASS_READERS  # noqa: PLC0415
 
@@ -488,6 +497,7 @@ def _read_dispatch(  # noqa: PLR0911
                     file_format=file_format,
                     progress_bar=progress_bar,
                     validate=validate,
+                    **kwargs,
                 ),
                 name,
             )
@@ -510,12 +520,14 @@ def _read_dispatch(  # noqa: PLR0911
         # natively (e.g. zarr stores on S3). If it fails, fall back to
         # downloading the file and retrying with a local path.
         ext_handler = _get_ext_handler(uri_ext)
-        if ext_handler is not None:
+        if ext_handler is not None and not _needs_reader_object(
+            uri_ext, progress_bar=progress_bar, validate=validate, kwargs=kwargs
+        ):
             try:
-                return ext_handler(filename)
+                return ext_handler(filename, **kwargs)
             except LocalFileRequiredError:
                 filename = _download_uri(filename, uri_ext)
-                return ext_handler(filename)
+                return ext_handler(filename, **kwargs)
         filename = _download_uri(filename, uri_ext)
 
     filename = Path(filename).expanduser().resolve()
@@ -536,7 +548,7 @@ def _read_dispatch(  # noqa: PLR0911
     if ext_handler is not None and not _needs_reader_object(
         ext, progress_bar=progress_bar, validate=validate, kwargs=kwargs
     ):
-        return ext_handler(str(filename))
+        return ext_handler(str(filename), **kwargs)
 
     if (missing := _missing_reader_message(ext, str(filename))) is not None:
         raise ImportError(missing)

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -323,9 +323,12 @@ def register_reader(
 
     * A bare **callable** ``handler(path, **kwargs)``. This is the
       lighter form for a format that has no reader-level state to
-      expose. :func:`pyvista.read` calls it directly;
-      :func:`pyvista.get_reader` raises :class:`ValueError` for the
-      extension because there is no reader object to hand back.
+      expose. :func:`pyvista.read` calls it directly, forwarding its
+      ``**kwargs``; :func:`pyvista.get_reader` raises
+      :class:`ValueError` for the extension because there is no reader
+      object to hand back. A callable registered with ``override=True``
+      is the exception: reader arguments for an extension PyVista
+      already reads route to the built-in reader instead.
 
     .. versionadded:: 0.48.0
 

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -16,6 +16,7 @@ import sys
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from unittest.mock import call
 from unittest.mock import patch
 import warnings
 
@@ -204,13 +205,108 @@ def test_read_with_custom_extension(tmp_path):
     assert isinstance(result, pv.PolyData)
 
 
+def test_read_forwards_kwargs_to_custom_handler(tmp_path):
+    test_file = tmp_path / 'data.myext'
+    test_file.touch()
+    mock = MagicMock(return_value=pv.PolyData())
+    pv.register_reader('.myext', mock)
+
+    pv.read(test_file, delimiter=',', skiprows=2)
+
+    mock.assert_called_once_with(str(test_file.resolve()), delimiter=',', skiprows=2)
+
+
+def test_custom_handler_kwargs_change_the_result(tmp_path):
+    test_file = tmp_path / 'data.myext'
+    test_file.touch()
+
+    @pv.register_reader('.myext')
+    def _reader(_path, *, theta_resolution=10):
+        return pv.Sphere(theta_resolution=theta_resolution)
+
+    assert pv.read(test_file, theta_resolution=30).n_points > pv.read(test_file).n_points
+
+
+def test_read_forwards_kwargs_to_each_file_in_a_sequence(tmp_path):
+    first = tmp_path / 'a.myext'
+    second = tmp_path / 'b.myext'
+    first.touch()
+    second.touch()
+    mock = MagicMock(return_value=pv.PolyData())
+    pv.register_reader('.myext', mock)
+
+    pv.read([first, second], normals=False)
+
+    assert mock.call_args_list == [
+        call(str(first.resolve()), normals=False),
+        call(str(second.resolve()), normals=False),
+    ]
+
+
+def test_read_forwards_kwargs_to_registered_class_in_a_sequence(tmp_path):
+    """A sequence read reaches the class-reader branch with its kwargs intact."""
+    first = tmp_path / 'a.myclassfmt'
+    second = tmp_path / 'b.myclassfmt'
+    first.touch()
+    second.touch()
+    pv.register_reader('.myclassfmt', _MockReader)
+
+    default = pv.read([first, second])
+    denser = pv.read([first, second], theta_resolution=30)
+
+    assert denser[0].n_points > default[0].n_points
+    assert denser[1].n_points > default[1].n_points
+
+
+def test_progress_bar_and_validate_are_not_forwarded_to_a_handler(tmp_path):
+    """A handler owns the whole read, so reader-object arguments stay behind."""
+    test_file = tmp_path / 'data.myext'
+    test_file.touch()
+    mock = MagicMock(return_value=pv.PolyData())
+    pv.register_reader('.myext', mock)
+
+    pv.read(test_file, progress_bar=True, validate=True)
+
+    mock.assert_called_once_with(str(test_file.resolve()))
+
+
+def test_read_kwargs_fall_back_to_the_builtin_reader(tmp_path):
+    """A handler overriding a built-in does not reinterpret its reader attributes."""
+    test_file = tmp_path / 'mesh.vtp'
+    pv.Sphere().save(test_file)
+    mock = MagicMock(return_value=pv.PolyData())
+    pv.register_reader('.vtp', mock, override=True)
+
+    assert pv.read(test_file).n_points == 0
+    with pytest.raises(AttributeError, match='not_an_attribute'):
+        pv.read(test_file, not_an_attribute=1)
+    mock.assert_called_once_with(str(test_file.resolve()))
+
+
+def test_uri_kwargs_fall_back_to_the_builtin_reader(tmp_path):
+    """The remote path gates the handler on kwargs exactly as the local one does."""
+    vtp_file = tmp_path / 'mesh.vtp'
+    pv.Sphere().save(vtp_file)
+    mock = MagicMock(return_value=pv.PolyData())
+    pv.register_reader('.vtp', mock, override=True)
+
+    with (
+        patch.dict('sys.modules', {'fsspec': None}),
+        patch('pooch.retrieve', return_value=str(vtp_file)),
+        pytest.raises(AttributeError, match='not_an_attribute'),
+    ):
+        pv.read('https://example.com/mesh.vtp', not_an_attribute=1)
+
+    mock.assert_not_called()
+
+
 def test_uri_forwarded_to_custom_reader():
     """Remote URI with a custom extension is passed directly to the handler."""
     mock = MagicMock(return_value=pv.PolyData())
     pv.register_reader('.myformat', mock)
 
-    result = pv.read('https://example.com/data.myformat')
-    mock.assert_called_once_with('https://example.com/data.myformat')
+    result = pv.read('https://example.com/data.myformat', normals=False)
+    mock.assert_called_once_with('https://example.com/data.myformat', normals=False)
     assert isinstance(result, pv.PolyData)
 
 
@@ -231,9 +327,12 @@ def test_uri_fallback_downloads_on_local_file_required(tmp_path):
 
     call_count = 0
 
-    def handler_needs_local(path, **__):
+    seen = []
+
+    def handler_needs_local(path, **kwargs):
         nonlocal call_count
         call_count += 1
+        seen.append(kwargs)
         if pv.has_scheme(path):
             raise pv.LocalFileRequiredError
         return pv.PolyData()
@@ -242,9 +341,10 @@ def test_uri_fallback_downloads_on_local_file_required(tmp_path):
 
     with patch.dict('sys.modules', {'fsspec': None}):
         with patch('pooch.retrieve', return_value=str(fake_file)):
-            result = pv.read('https://example.com/data.myformat')
+            result = pv.read('https://example.com/data.myformat', normals=False)
 
     assert call_count == 2  # first with URI, second with local path
+    assert seen == [{'normals': False}, {'normals': False}]
     assert isinstance(result, pv.PolyData)
 
 
@@ -662,8 +762,7 @@ def test_read_uses_registered_class(custom_file):
 def test_read_forwards_kwargs_to_registered_class(custom_file):
     """A class reader gets ``pv.read`` kwargs as reader attributes.
 
-    This is what a bare callable handler cannot do: ``pv.read`` drops its
-    kwargs on that path.
+    A bare callable handler receives the same kwargs as call arguments.
     """
     pv.register_reader('.myclassfmt', _MockReader)
     default = pv.read(custom_file)


### PR DESCRIPTION
### Overview

`pv.read` dropped its keyword arguments whenever it dispatched to a callable registered through `pyvista.register_reader`, so every option such a reader exposes was unreachable from the public entry point and a caller who passed one got silence rather than an error. The registry documents handlers as `handler(path, **kwargs)` (#8950), so the dispatcher was contradicting its own contract. The sequence branch of `_read_dispatch` dropped them for every reader kind, class readers included, so `pv.read([a, b], skip_zero_time=True)` was ignored too; that is fixed here as well.

A callable registered with `override=True` still steps aside to the built-in reader when it is handed reader arguments, since for an extension PyVista already reads those names mean the built-in reader's attributes. The remote-URI branch had no such gate and now shares the local one.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
