### PR TITLE
Fix crash when cells reference missing point ids

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -599,7 +599,7 @@ class _MeshValidator(Generic[_DataSetOrMultiBlockType]):
         def get_message(array_):
             if array_:
                 # Create separate message of each cell type
-                cell_types = sorted(mesh.distinct_cell_types)
+                cell_types = sorted(_distinct_cell_types(mesh))
                 if len(cell_types) > 1:
                     all_cell_types = mesh.cast_to_unstructured_grid().celltypes
                     arrays = []
@@ -1053,17 +1053,13 @@ class _MeshValidationReport(_NoNewAttrMixin, Generic[_DataSetOrMultiBlockType]):
             mesh_items['N Points'] = mesh.n_points
             mesh_items['N Cells'] = mesh.n_cells
 
-            # Get distinct cell types
-            if pv.vtk_version_info < (9, 5, 0):
-                # This may cast to unstructured grid, which will warn if arrays are invalid
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        'ignore',
-                        category=pv.InvalidMeshWarning,
-                    )
-                    cell_types_ = mesh.distinct_cell_types
-            else:
-                cell_types_ = mesh.distinct_cell_types
+            # This may cast to unstructured grid, which will warn if arrays are invalid
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore',
+                    category=pv.InvalidMeshWarning,
+                )
+                cell_types_ = _distinct_cell_types(mesh)
 
             # Use a list to preserve order, but we format it to look like a set
             cell_types = sorted(cell_types_)
@@ -1554,6 +1550,11 @@ class DataObjectFilters:
         Internally, :vtk:`vtkCellValidator` is first used to determine the initial status of each
         cell, then additional PyVista-exclusive checks are made and encoded in the validity state.
 
+        .. note::
+            When any cell of the mesh references a point id which does not exist, only the
+            :attr:`~pyvista.CellStatus.INVALID_POINT_REFERENCES` and
+            :attr:`~pyvista.CellStatus.COINCIDENT_POINTS` statuses are checked.
+
         For convenience, a field data array for each status is also appended:
 
         - Each field data array contains the indices of cells with the specified status.
@@ -1732,8 +1733,12 @@ class DataObjectFilters:
             msg = 'Planarity tolerance requires VTK 9.6 or later.'
             raise pv.VTKVersionError(msg)
 
+        # A cell referencing a point id which does not exist makes VTK read out of bounds,
+        # so skip the checks which dereference cell points when the connectivity is invalid
+        invalid_references = _has_invalid_point_references(self)
+
         # Skip to avoid crash with ImageData/RectilinearGrid, see https://gitlab.kitware.com/vtk/vtk/-/work_items/20096
-        skip_validator = isinstance(self, pv.Grid)
+        skip_validator = isinstance(self, pv.Grid) or invalid_references
         if skip_validator:
             output = self.copy(deep=False)
         else:
@@ -1753,7 +1758,7 @@ class DataObjectFilters:
             # Make scalars 64-bit, rename, and make them active
             # We only need 32 bits for the state, but the CellStatus enum requires 64-bit
             if skip_validator:
-                validity_state = np.zeros(shape=(self.n_cells,), dtype=np.int64)
+                validity_state = np.zeros(shape=(mesh.n_cells,), dtype=np.int64)
             else:
                 validity_state = np.array(
                     mesh.cell_data['ValidityState'],
@@ -1775,28 +1780,31 @@ class DataObjectFilters:
                 mesh.field_data[status.name.lower()] = np.where(validity_state & status.value)[0]
 
         def set_pyvista_validity_state(mesh: DataSet):
-            # Use points dtype eps by default
-            size_tol: float = (
-                size_tolerance if size_tolerance is not None else np.finfo(mesh.points.dtype).eps
-            )
-
             state = mesh.cell_data['validity_state']
 
-            size_data = mesh.compute_cell_sizes(
-                vertex_count=True, length=True, area=True, volume=True
-            ).cell_data
-            size = (
-                size_data['VertexCount']
-                + size_data['Length']
-                + size_data['Area']
-                + size_data['Volume']
-            )
+            # A cell's size cannot be computed when its points do not exist
+            if not invalid_references:
+                # Use points dtype eps by default
+                size_tol: float = (
+                    size_tolerance
+                    if size_tolerance is not None
+                    else np.finfo(mesh.points.dtype).eps
+                )
+                size_data = mesh.compute_cell_sizes(
+                    vertex_count=True, length=True, area=True, volume=True
+                ).cell_data
+                size = (
+                    size_data['VertexCount']
+                    + size_data['Length']
+                    + size_data['Area']
+                    + size_data['Volume']
+                )
 
-            # NEGATIVE_SIZE
-            state[size < -size_tol] |= CellStatus.NEGATIVE_SIZE
+                # NEGATIVE_SIZE
+                state[size < -size_tol] |= CellStatus.NEGATIVE_SIZE
 
-            # ZERO_SIZE
-            state[np.abs(size) <= size_tol] |= CellStatus.ZERO_SIZE
+                # ZERO_SIZE
+                state[np.abs(size) <= size_tol] |= CellStatus.ZERO_SIZE
 
             # COINCIDENT_POINTS
             # Skip remaining checks for datasets where cell connectivity cannot be invalid
@@ -5538,6 +5546,48 @@ def _convex_hull_scipy(points: NumpyArray[float], dimensionality: Literal[1, 2, 
         remap[vertex_ids] = np.arange(len(vertex_ids))
         faces = remap[hull.simplices]
     return pv.PolyData.from_regular_faces(hull_points, faces)
+
+
+def _distinct_cell_types(mesh: DataSet) -> set[CellType]:
+    """Return the mesh's distinct cell types without reading the points of its cells.
+
+    :attr:`~pyvista.DataSet.distinct_cell_types` builds every cell, so a cell referencing a
+    point id which does not exist makes VTK read out of bounds.
+    """
+    if not isinstance(mesh, (pv.PolyData, pv.UnstructuredGrid)):
+        # Connectivity is implicit and cannot reference an invalid point id
+        return mesh.distinct_cell_types
+    grid = mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
+    cell_types = {CellType(cell_type) for cell_type in np.unique(grid.celltypes)}
+    if mesh._has_hidden_cells:
+        cell_types.add(CellType.EMPTY_CELL)
+    return cell_types
+
+
+def _has_invalid_point_references(dataset: DataSet | MultiBlock) -> bool:
+    """Return ``True`` if any cell of a mesh or of its blocks references a missing point id."""
+    blocks = (
+        dataset.recursive_iterator(skip_none=True)
+        if isinstance(dataset, pv.MultiBlock)
+        else [dataset]
+    )
+    for mesh in blocks:
+        if isinstance(mesh, pv.PolyData):
+            arrays = [
+                mesh.vert_connectivity,
+                mesh.line_connectivity,
+                mesh.face_connectivity,
+                mesh.strip_connectivity,
+            ]
+        elif isinstance(mesh, pv.UnstructuredGrid):
+            arrays = [mesh.cell_connectivity]
+        else:
+            # Connectivity is implicit and cannot reference an invalid point id
+            continue
+        n_points = mesh.n_points
+        if any(np.any((ids < 0) | (ids >= n_points)) for ids in arrays):
+            return True
+    return False
 
 
 def _composite_has_pointset(dataset: DataSet | MultiBlock) -> bool:

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -3055,7 +3055,19 @@ def test_validate_mesh_invalid_point_references():
 
 
 @pytest.mark.parametrize('n_points', [3, 131072], ids=['small', 'large'])
-@pytest.mark.parametrize('mesh_type', [pv.PolyData, pv.UnstructuredGrid])
+@pytest.mark.parametrize(
+    'mesh_type',
+    [
+        pytest.param(
+            pv.PolyData,
+            marks=pytest.mark.needs_vtk_version(
+                (9, 5, 0),
+                reason='Casting PolyData to UnstructuredGrid does not preserve invalid ids',
+            ),
+        ),
+        pv.UnstructuredGrid,
+    ],
+)
 def test_validate_mesh_invalid_point_references_is_only_status(mesh_type, n_points):
     # The large mesh is included since reading a point beyond the last one may fault
     points = np.zeros((n_points, 3))

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -3054,6 +3054,31 @@ def test_validate_mesh_invalid_point_references():
     assert report.invalid_point_references == expected_cell_ids
 
 
+@pytest.mark.parametrize('n_points', [3, 131072], ids=['small', 'large'])
+@pytest.mark.parametrize('mesh_type', [pv.PolyData, pv.UnstructuredGrid])
+def test_validate_mesh_invalid_point_references_is_only_status(mesh_type, n_points):
+    # The large mesh is included since reading a point beyond the last one may fault
+    points = np.zeros((n_points, 3))
+    cells = [3, 0, 1, n_points]
+    mesh = (
+        pv.PolyData(points, faces=cells)
+        if mesh_type is pv.PolyData
+        else pv.UnstructuredGrid(cells, [pv.CellType.TRIANGLE], points)
+    )
+
+    validated = mesh.cell_validator()
+    assert validated.cell_data['validity_state'][0] == pv.CellStatus.INVALID_POINT_REFERENCES
+    assert validated.field_data['invalid'].tolist() == [0]
+    for name in CELL_STATUS_ARRAY_NAMES:
+        expected = [0] if name == 'invalid_point_references' else []
+        assert validated.field_data[name].tolist() == expected
+
+    report = mesh.validate_mesh(exclude_fields=['unused_points'])
+    assert report.invalid_fields == ('invalid_point_references',)
+    assert 'TRIANGLE cell with invalid point references' in report.message
+    assert '{TRIANGLE}' in str(report)
+
+
 @pytest.fixture
 def invalid_hexahedron():
     points = [


### PR DESCRIPTION
### Overview

A cell whose point ids are negative or past the last point makes VTK read out of bounds: `vtkCellValidator`, the cell size filter and `vtkDataSet::GetDistinctCellTypes` all build each cell from its point ids, so `cell_validator` and `validate_mesh` can segfault on exactly the meshes they exist to diagnose. Those cells are now found from the connectivity arrays first and the checks that would dereference them are skipped, so a mesh containing one only reports `invalid_point_references` and `coincident_points`.

Whether the read faults depends on whether it leaves the points array's allocation, so this has surfaced as an intermittent worker crash rather than a reliable failure — most recently on macOS in [this run](https://github.com/pyvista/pyvista/actions/runs/34078954271/job/101613734843).

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
