### PR TITLE
Support native point shapes on actor properties

### DIFF
--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -13,6 +13,7 @@ from pyvista._warn_external import warn_external
 from pyvista.core.utilities.arrays import get_array
 from pyvista.core.utilities.misc import assert_empty_kwargs
 
+from ._property import _HAS_NATIVE_POINT_SHAPES
 from .colors import Color
 from .opts import InterpolationType
 from .tools import opacity_transfer_function
@@ -455,7 +456,7 @@ def _common_arg_parser(
     if point_shape is None:
         point_shape = theme.point_shape
 
-    if point_shape is not None and render_points_as_spheres:
+    if point_shape is not None and render_points_as_spheres and not _HAS_NATIVE_POINT_SHAPES:
         warn_external(
             f'point_shape={point_shape!r} requires render_points_as_spheres=False. '
             'Disabling render_points_as_spheres.',

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -12,7 +12,10 @@ from pyvista.core.utilities.misc import _NoNewAttrMixin
 
 from .colors import Color
 from .opts import InterpolationType
+from .opts import PointSpriteShape
 from .opts import RepresentationType
+
+_HAS_NATIVE_POINT_SHAPES = hasattr(getattr(_vtk.vtkProperty, 'Point2DShapeType', None), 'Star')
 
 
 class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
@@ -212,6 +215,8 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         if point_size is None:
             point_size = self._theme.point_size
         self.point_size = point_size
+        if _HAS_NATIVE_POINT_SHAPES:
+            self.point_shape = self._theme.point_shape or 'square'
         if opacity is None:
             opacity = self._theme.opacity
         self.opacity = opacity
@@ -249,6 +254,52 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         if edge_opacity is None:
             edge_opacity = self._theme.edge_opacity
         self.edge_opacity = edge_opacity
+
+    @property
+    def point_shape(self) -> str:  # numpydoc ignore=RT01
+        """Return or set the shape of flat point primitives.
+
+        Shapes are ``'square'``, ``'circle'``, ``'triangle'``, ``'hexagon'``,
+        ``'diamond'``, ``'asterisk'``, and ``'star'``. The shape applies to
+        vertex cells in surface and wireframe representations as well as
+        points representation. Sphere rendering takes precedence while enabled.
+
+        .. versionadded:: 0.49
+
+        .. note::
+            Setting this property requires a graphics backend with native
+            point-shape support. :meth:`pyvista.Actor.set_point_sprite_shape`
+            also supports older backends in points representation.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> prop = pv.Property()
+        >>> prop.point_shape
+        'square'
+
+        """
+        if not _HAS_NATIVE_POINT_SHAPES:
+            return 'square'
+        shape = self.GetPoint2DShape()
+        for name in ('square', *(item.value for item in PointSpriteShape)):
+            native_name = 'Round' if name == 'circle' else name.capitalize()
+            if shape == getattr(self.Point2DShapeType, native_name, None):
+                return name
+        msg = f'Unknown native point shape {shape!r}.'
+        raise ValueError(msg)
+
+    @point_shape.setter
+    def point_shape(self, shape: PointSpriteShape | str) -> None:
+        if shape not in ('square', *PointSpriteShape):
+            msg = f'Invalid point sprite shape {shape!r}.'
+            raise ValueError(msg)
+        if not _HAS_NATIVE_POINT_SHAPES:
+            msg = 'This graphics backend does not support native point shapes.'
+            raise VTKVersionError(msg)
+        name = shape.value if isinstance(shape, PointSpriteShape) else shape
+        native_name = 'Round' if name == 'circle' else name.capitalize()
+        self.SetPoint2DShape(getattr(self.Point2DShapeType, native_name))
 
     @property
     def style(self) -> str:  # numpydoc ignore=RT01

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -12,6 +12,7 @@ from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 from pyvista._warn_external import warn_external
 
+from ._property import _HAS_NATIVE_POINT_SHAPES
 from ._property import Property
 from .opts import PointSpriteShape
 from .opts import ShaderType
@@ -844,6 +845,28 @@ class Actor(Prop3D, _vtk.vtkActor):
         """
         self.clear_shader_replacements(_feature_name='mip')
 
+    @property
+    def point_sprite_shape(self) -> str:  # numpydoc ignore=RT01
+        """Return the requested point shape, including ``'square'``.
+
+        The shape is retained when another representation or sphere rendering
+        makes it inactive.
+
+        .. versionadded:: 0.49
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> actor = pv.Actor()
+        >>> actor.set_point_sprite_shape('circle')
+        >>> actor.point_sprite_shape
+        'circle'
+
+        """
+        if _HAS_NATIVE_POINT_SHAPES:
+            return self.prop.point_shape
+        return self._point_sprite_shape or 'square'
+
     def set_point_sprite_shape(self, shape: PointSpriteShape | str) -> None:
         """Set a custom point sprite shape via fragment shader.
 
@@ -853,15 +876,12 @@ class Actor(Prop3D, _vtk.vtkActor):
         defined by a GLSL fragment shader. This uses the ``discard``
         instruction to clip fragments outside the desired shape boundary.
 
-        The chosen shape is **persisted on the actor** and is only
-        injected into the fragment shader while the actor's
-        :attr:`~pyvista.Property.style` is ``'points'``. When the style
-        is ``'surface'`` or ``'wireframe'`` the shader replacement is
-        transparently removed, because the underlying GLSL relies on
-        ``gl_PointCoord`` which is undefined for non-point primitives
-        and would otherwise corrupt the rendering. Switching
-        ``prop.style`` back to ``'points'`` later will re-install the
-        shader automatically.
+        With native point-shape support, the shape is stored on
+        :attr:`pyvista.Property.point_shape` and applies to point primitives
+        in every representation, including vertex cells in surfaces.
+        Sphere rendering takes precedence while enabled. Older backends use
+        a shader replacement active only in ``'points'`` representation.
+        The requested shape can be read from :attr:`point_sprite_shape`.
 
         Parameters
         ----------
@@ -914,6 +934,9 @@ class Actor(Prop3D, _vtk.vtkActor):
             msg = f'Invalid point sprite shape {shape!r}. Must be one of: {valid}'
             raise ValueError(msg)
 
+        if _HAS_NATIVE_POINT_SHAPES:
+            self.prop.point_shape = shape
+            return
         self._point_sprite_shape = shape.value if isinstance(shape, PointSpriteShape) else shape
         self._install_point_sprite_observer()
         self._sync_point_sprite_shader()
@@ -938,6 +961,9 @@ class Actor(Prop3D, _vtk.vtkActor):
         >>> actor.clear_point_sprite_shape()
 
         """
+        if _HAS_NATIVE_POINT_SHAPES:
+            self.prop.point_shape = 'square'
+            return
         self._point_sprite_shape = None
         if self._point_sprite_observer is not None:
             self.prop.RemoveObserver(self._point_sprite_observer)

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -3807,11 +3807,18 @@ class BasePlotter(_BoundsSizeMixin):
             Accepts a :class:`pyvista.plotting.opts.PointSpriteShape`
             enum value or a string. Must be one of ``'circle'``,
             ``'triangle'``, ``'hexagon'``, ``'diamond'``, ``'asterisk'``,
-            or ``'star'``. Requires ``style='points'``. If
-            ``render_points_as_spheres`` is ``True`` (explicitly or via
-            theme), it will be automatically disabled with a warning.
+            or ``'star'``. Backends with native point shapes apply the shape
+            to vertex cells in all representation styles. Spheres and
+            Gaussian splats retain their own silhouettes.
+
+            On older backends, requires ``style='points'`` and automatically
+            disables ``render_points_as_spheres`` with a warning.
 
             .. versionadded:: 0.48
+
+            .. versionchanged:: 0.49
+                Native point shapes apply to vertices in all representations
+                and preserve explicit sphere rendering.
 
         render_lines_as_tubes : bool, optional
             Show lines as thick tubes rather than flat lines.  Control

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -8,6 +8,7 @@ import scipy
 import pyvista as pv
 from pyvista import _vtk
 from pyvista import examples
+from pyvista.plotting._property import _HAS_NATIVE_POINT_SHAPES
 from pyvista.plotting.actor import _POINT_SPRITE_SHADERS
 from pyvista.plotting.prop3d import Prop3D
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
@@ -652,15 +653,21 @@ def test_set_point_sprite_shape(shape):
         point_size=20,
     )
     actor.set_point_sprite_shape(shape)
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == shape
+    if _HAS_NATIVE_POINT_SHAPES:
+        assert actor.prop.point_shape == shape
+        assert 'point_sprite' not in actor._shader_replacements
+    else:
+        assert len(actor._shader_replacements['point_sprite']) == 1
 
 
 def test_clear_point_sprite_shape(point_cloud_actor):
     actor = point_cloud_actor
     actor.set_point_sprite_shape('circle')
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == 'circle'
 
     actor.clear_point_sprite_shape()
+    assert actor.point_sprite_shape == 'square'
     assert 'point_sprite' not in actor._shader_replacements
 
 
@@ -678,21 +685,22 @@ def test_add_mesh_point_shape():
     cloud = pv.PolyData(np.random.default_rng(0).random((100, 3)))
     pl = pv.Plotter()
     actor = pl.add_mesh(cloud, style='points', point_shape='circle', point_size=20)
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == 'circle'
 
 
 def test_add_mesh_point_shape_enum():
     cloud = pv.PolyData(np.random.default_rng(0).random((100, 3)))
     pl = pv.Plotter()
     actor = pl.add_mesh(cloud, style='points', point_shape=pv.PointSpriteShape.STAR, point_size=20)
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == 'star'
 
 
 def test_set_point_sprite_shape_enum(point_cloud_actor):
     point_cloud_actor.set_point_sprite_shape(pv.PointSpriteShape.HEXAGON)
-    assert 'point_sprite' in point_cloud_actor._shader_replacements
+    assert point_cloud_actor.point_sprite_shape == 'hexagon'
 
 
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy shader/sphere exclusion')
 def test_add_mesh_point_shape_disables_spheres():
     cloud = pv.PolyData(np.random.default_rng(0).random((100, 3)))
     pl = pv.Plotter()
@@ -713,11 +721,12 @@ def test_theme_point_shape():
         pv.global_theme.point_shape = 'hexagon'
         pl = pv.Plotter()
         actor = pl.add_mesh(cloud, style='points')
-        assert 'point_sprite' in actor._shader_replacements
+        assert actor.point_sprite_shape == 'hexagon'
     finally:
         pv.global_theme.point_shape = None
 
 
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy shader/sphere exclusion')
 def test_theme_point_shape_disables_spheres():
     cloud = pv.PolyData(np.random.default_rng(0).random((100, 3)))
     try:
@@ -744,11 +753,11 @@ def test_mip_and_point_sprite_coexist(point_cloud_actor):
     actor.set_point_sprite_shape('circle')
 
     assert 'mip' in actor._shader_replacements
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == 'circle'
 
     actor.disable_maximum_intensity_projection()
     assert 'mip' not in actor._shader_replacements
-    assert 'point_sprite' in actor._shader_replacements
+    assert actor.point_sprite_shape == 'circle'
 
     actor.enable_maximum_intensity_projection()
     assert 'mip' in actor._shader_replacements

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -643,7 +643,8 @@ def test_mip_no_mapper():
     'shape',
     ['circle', 'triangle', 'hexagon', 'diamond', 'asterisk', 'star'],
 )
-def test_set_point_sprite_shape(shape):
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy point-sprite shader replacement')
+def test_set_point_sprite_shape_legacy_shader(shape):
     cloud = pv.PolyData(np.random.default_rng(0).random((100, 3)))
     pl = pv.Plotter()
     actor = pl.add_mesh(
@@ -654,11 +655,7 @@ def test_set_point_sprite_shape(shape):
     )
     actor.set_point_sprite_shape(shape)
     assert actor.point_sprite_shape == shape
-    if _HAS_NATIVE_POINT_SHAPES:
-        assert actor.prop.point_shape == shape
-        assert 'point_sprite' not in actor._shader_replacements
-    else:
-        assert len(actor._shader_replacements['point_sprite']) == 1
+    assert len(actor._shader_replacements['point_sprite']) == 1
 
 
 def test_clear_point_sprite_shape(point_cloud_actor):

--- a/tests/plotting/test_native_point_shapes.py
+++ b/tests/plotting/test_native_point_shapes.py
@@ -1,0 +1,158 @@
+"""Native point shapes preserve topology and survive property round trips."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import pyvista as pv
+from pyvista.plotting._property import _HAS_NATIVE_POINT_SHAPES
+
+
+@pytest.fixture
+def native_property_api(monkeypatch):
+    """Exercise Python wrapper contracts independently of native rendering."""
+    # mocked: stock VTK lacks the extended enum/API. Substitute only that binding
+    # for wrapper tests; rendering and native DeepCopy tests never use this shim.
+    shapes = {}
+    names = ('Round', 'Square', 'Triangle', 'Hexagon', 'Diamond', 'Asterisk', 'Star')
+    monkeypatch.setattr(
+        pv.Property,
+        'Point2DShapeType',
+        SimpleNamespace(**{name: index for index, name in enumerate(names)}),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pv.Property, 'GetPoint2DShape', lambda self: shapes[self.__this__], raising=False
+    )
+    monkeypatch.setattr(
+        pv.Property,
+        'SetPoint2DShape',
+        lambda self, value: shapes.__setitem__(self.__this__, value),
+        raising=False,
+    )
+    for module in ('_property', 'actor', '_plotting'):
+        monkeypatch.setattr(f'pyvista.plotting.{module}._HAS_NATIVE_POINT_SHAPES', True)
+
+
+@pytest.mark.parametrize(
+    ('shape', 'native_name'),
+    [
+        ('circle', 'Round'),
+        ('triangle', 'Triangle'),
+        ('hexagon', 'Hexagon'),
+        ('diamond', 'Diamond'),
+        ('asterisk', 'Asterisk'),
+        ('star', 'Star'),
+    ],
+)
+@pytest.mark.usefixtures('native_property_api')
+@pytest.mark.parametrize('as_enum', [False, True])
+def test_native_shape_is_property_state(shape, native_name, as_enum):
+    """Actors read the property, including changes made outside the actor API."""
+    shape = pv.PointSpriteShape(shape) if as_enum else shape
+    actor = pv.Actor()
+    actor.set_point_sprite_shape(shape)
+    assert actor.prop.GetPoint2DShape() == getattr(actor.prop.Point2DShapeType, native_name)
+    assert actor.prop.point_shape == shape
+    assert not actor._shader_replacements
+    actor.prop.point_shape = 'square'
+    assert actor.point_sprite_shape == 'square'
+    actor.prop.point_shape = shape
+    assert actor.point_sprite_shape == shape
+    actor.clear_point_sprite_shape()
+    assert actor.point_sprite_shape == 'square'
+
+
+@pytest.mark.parametrize('shape', list(pv.PointSpriteShape))
+def test_native_shape_copy(shape):
+    """Real C++ DeepCopy preserves shape independently of the original actor."""
+    actor = pv.Actor()
+    actor.set_point_sprite_shape(shape)
+    restored = pv.Actor(prop=actor.prop.copy())
+    expected_shape = actor.prop.point_shape
+    assert expected_shape == (shape if _HAS_NATIVE_POINT_SHAPES else 'square')
+    actor.clear_point_sprite_shape()
+    assert restored.point_sprite_shape == expected_shape
+
+
+@pytest.mark.parametrize('style', ['surface', 'wireframe', 'points'])
+def test_theme_circle_reaches_rendered_vertex_cells(style):
+    """An omitted shape renders circles from the plotter's own theme."""
+    if style != 'points' and not _HAS_NATIVE_POINT_SHAPES:
+        pytest.skip('Requires native point-shape rendering outside points representation')
+    theme = pv.themes.Theme()
+    theme.point_shape = 'circle'
+    theme.multi_samples = 0
+    cloud = pv.PolyData(np.array([[0.0, 0.0, 0.0]]))
+    pl = pv.Plotter(theme=theme, window_size=(200, 200))
+    actor = pl.add_mesh(cloud, style=style, point_size=40, lighting=False, color='white')
+    pl.background_color = 'black'
+    pl.camera_position = [(0, 0, 10), (0, 0, 0), (0, 1, 0)]
+    pl.enable_parallel_projection()
+    pl.camera.parallel_scale = 2
+    pl.show(auto_close=False)
+    circle = pl.screenshot()
+    actor.clear_point_sprite_shape()
+    pl.render()
+    square = pl.screenshot()
+    pl.close()
+    assert circle[100, 100, 0] == square[100, 100, 0] == 255
+    assert circle[82, 82, 0] == 0
+    assert square[82, 82, 0] == 255
+    assert 0.72 < np.count_nonzero(circle) / np.count_nonzero(square) < 0.84
+
+
+@pytest.mark.usefixtures('native_property_api')
+def test_explicit_spheres_override_theme_circle():
+    """The theme's flat shape does not disable an explicit sphere request."""
+    theme = pv.themes.Theme()
+    theme.point_shape = 'circle'
+    pl = pv.Plotter(theme=theme)
+    actor = pl.add_mesh(pv.PolyData(np.array([[0.0, 0.0, 0.0]])), render_points_as_spheres=True)
+    assert actor.prop.render_points_as_spheres
+    assert actor.point_sprite_shape == 'circle'
+    pl.close()
+
+
+@pytest.mark.usefixtures('native_property_api')
+def test_property_uses_its_own_theme():
+    """A property created without add_mesh still resolves the theme default."""
+    theme = pv.themes.Theme()
+    theme.point_shape = 'diamond'
+    assert pv.Property(theme=theme).point_shape == theme.point_shape
+
+
+@pytest.mark.usefixtures('native_property_api')
+def test_invalid_native_shape_preserves_the_previous_shape():
+    """Invalid input cannot silently clear the selected shape."""
+    prop = pv.Property()
+    prop.point_shape = 'circle'
+    with pytest.raises(ValueError, match='Invalid point sprite shape'):
+        prop.point_shape = 'pentagon'
+    assert prop.point_shape == 'circle'
+
+
+@pytest.mark.usefixtures('native_property_api')
+def test_unknown_native_shape(monkeypatch):
+    """An unrecognized backend value is not silently reported as square."""
+    prop = pv.Property()
+    # mocked: the binding cannot construct an unknown C++ enum value.
+    monkeypatch.setattr(pv.Property, 'GetPoint2DShape', lambda _self: 99)
+    with pytest.raises(ValueError, match='Unknown native point shape'):
+        _ = prop.point_shape
+
+
+def test_property_shape_without_native_support(monkeypatch):
+    """Unsupported setters refuse valid shapes and validate invalid inputs."""
+    # mocked: exercise the unsupported-backend contract on native backends too.
+    monkeypatch.setattr('pyvista.plotting._property._HAS_NATIVE_POINT_SHAPES', False)
+    prop = pv.Property()
+    assert prop.point_shape == 'square'
+    with pytest.raises(pv.VTKVersionError, match='does not support native point shapes'):
+        prop.point_shape = 'circle'
+    with pytest.raises(ValueError, match='Invalid point sprite shape'):
+        prop.point_shape = 'pentagon'
+    assert prop.point_shape == 'square'

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -32,6 +32,7 @@ from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.plotting import BackgroundPlotter
 from pyvista.plotting import QtDeprecationError
 from pyvista.plotting import QtInteractor
+from pyvista.plotting._property import _HAS_NATIVE_POINT_SHAPES
 from pyvista.plotting.axes_assembly import ScaleModeOptions
 from pyvista.plotting.colors import matplotlib_default_colors
 from pyvista.plotting.errors import InvalidCameraError
@@ -7421,7 +7422,7 @@ def test_point_sprite_shape_does_not_apply_to_surface(shape):
     )
     # The shape is persisted on the actor, but the shader replacement
     # must NOT be installed while the representation is 'Surface'.
-    assert actor._point_sprite_shape == shape
+    assert actor.point_sprite_shape == shape
     assert not actor._point_sprite_applied
     assert 'point_sprite' not in actor._shader_replacements
     pl.show()
@@ -7454,6 +7455,7 @@ def test_point_sprite_shape_change_style(shape, verify_image_cache_wrapper):
     pl.show()
 
 
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy shader replacement lifecycle')
 def test_point_sprite_shape_transition_updates_shader(no_images_to_verify):  # noqa: ARG001
     # Regression: if the applied-state is tracked as a boolean, calling
     # set_point_sprite_shape with a new shape while the previous shape
@@ -7475,6 +7477,7 @@ def test_point_sprite_shape_transition_updates_shader(no_images_to_verify):  # n
     assert 'point_sprite' not in actor._shader_replacements
 
 
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy shader replacement lifecycle')
 def test_point_sprite_shape_observer_tracks_representation(no_images_to_verify):  # noqa: ARG001
     # With a shape persisted on the actor, toggling the representation
     # between Points and Surface must install / remove the shader via
@@ -7496,6 +7499,7 @@ def test_point_sprite_shape_observer_tracks_representation(no_images_to_verify):
     assert 'point_sprite' in actor._shader_replacements
 
 
+@pytest.mark.skipif(_HAS_NATIVE_POINT_SHAPES, reason='Legacy shader replacement lifecycle')
 def test_clear_point_sprite_shape_detaches_observer(no_images_to_verify):  # noqa: ARG001
     actor = pv.Actor()
     actor.prop.style = 'points'
@@ -7518,8 +7522,7 @@ def test_set_point_sprite_shape_accepts_enum(no_images_to_verify):  # noqa: ARG0
     actor = pv.Actor()
     actor.prop.style = 'points'
     actor.set_point_sprite_shape(PointSpriteShape.TRIANGLE)
-    assert actor._point_sprite_shape == 'triangle'
-    assert actor._point_sprite_applied == 'triangle'
+    assert actor.point_sprite_shape == 'triangle'
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ vtk_latest_install = uv pip install --upgrade --pre --no-deps vtk
 # `cvista[all]`, not bare `cvista`: the bare tier is rendering- and IO-free and cannot
 # run the plotting suite. cvista >=9.7.0.2 ships every reader and writer the suite
 # exercises, including the parallel Exodus reader added in 9.7.0.1.
-cvista_install = uv pip install --upgrade --no-cache cvista[all]>=9.7.0.2,<9.8.0
+cvista_install = uv pip install --upgrade --no-cache {env:CVISTA_INSTALL_SPEC:cvista[all]>=9.7.0.2,<9.8.0}
 # --no-deps so `--upgrade` does not lift PyVista's own pins (their deps come from
 # the `test` group); a matplotlib bump otherwise fails tests/doc/test_tables.py.
 # trame-vtk >=2.11.16 (Kitware/trame-vtk#124) honours VTK_MODULE_NAME; earlier
@@ -178,7 +178,7 @@ description =
     cvista: Run the test suite against the cvista VTK backend
     nightly: Run the test suite against the nightly numpy and matplotlib wheels
 basepython =
-    cvista: py3.13
+    cvista: {env:CVISTA_PYTHON:py3.13}
     nightly: py3.14
 dependency_groups = test
 # Not in the `test` group; guards against a single stuck test burning the job budget.


### PR DESCRIPTION
Point shapes selected through native actor properties now survive property copies and apply to vertex cells in Surface and Wireframe representations. `Property.point_shape` exposes the native setting, and `Actor.point_sprite_shape` reads it back. Backends without native support retain the existing shader path; native sphere rendering keeps its own silhouette.

This change is based directly on `main` and contains only point-shape support, its documentation and tests, and configurable native-backend test inputs.

Validation: `make lint`, `make typecheck`, and `make doctest` pass (1,917 doctests). The focused stock-VTK regression selection passes 64 tests, with two native-rendering skips; all 26 point-shape tests pass against a native backend. The updated point-shape test module has 100% local line and branch coverage. A paired getter/setter mapping mutation produces four expected failures.

Wrapper contract tests use a scoped substitute for the extended native binding. Property-copy and pixel-rendering tests use real backends. Unsupported-backend setters and unknown native values are tested explicitly.

`make docstyle` reports existing `dtype`/`uncast` vocabulary and heading errors in unchanged files; the previous CI Vale log reports the same diagnostics despite its passing status.

Drafted and tested with Codex.
