### PR TITLE
Annotate the return type of the connectivity filters

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -257,6 +257,8 @@ nitpick_ignore_regex = [
     (r'py:.*', '.*NormalsLiteral'),
     (r'py:.*', '.*_CellQualityLiteral'),
     (r'py:.*', '.*_CompressionOptions'),
+    (r'py:.*', '.*_ConnectivityMode'),
+    (r'py:.*', '.*_RegionAssignmentMode'),
     (r'py:.*', '.*_SENTINEL'),
     (r'py:.*', '.*T'),
     (r'py:.*', '.*Options'),

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2248,74 +2248,32 @@ class DataSetFilters(DataObjectFilters):
 
         return output
 
+    # fmt: off
     @overload
-    def connectivity(  # type: ignore[misc]
-        self: PolyData,
-        extraction_mode: _ConnectivityMode = ...,
-        variable_input: (
-            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
-        ) = ...,
-        scalar_range: VectorLike[float] | None = ...,
-        scalars: str | None = ...,
-        label_regions: bool = ...,  # noqa: FBT001
-        region_assignment_mode: _RegionAssignmentMode = ...,
-        region_ids: int | VectorLike[int] | None = ...,
-        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        closest_point: VectorLike[float] | None = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        **kwargs,
-    ) -> PolyData: ...
+    def connectivity(self: PolyData, extraction_mode: _ConnectivityMode = ..., variable_input: float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None = ..., scalar_range: VectorLike[float] | None = ..., scalars: str | None = ..., label_regions: bool = ..., region_assignment_mode: _RegionAssignmentMode = ..., region_ids: int | VectorLike[int] | None = ..., point_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., closest_point: VectorLike[float] | None = ..., inplace: bool = ..., progress_bar: bool = ..., **kwargs) -> PolyData: ...  # type: ignore[misc]  # noqa: E501, FBT001
     @overload
-    def connectivity(  # type: ignore[misc]
-        self: PointSet,
-        extraction_mode: _ConnectivityMode = ...,
-        variable_input: (
-            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
-        ) = ...,
-        scalar_range: VectorLike[float] | None = ...,
-        scalars: str | None = ...,
-        label_regions: bool = ...,  # noqa: FBT001
-        region_assignment_mode: _RegionAssignmentMode = ...,
-        region_ids: int | VectorLike[int] | None = ...,
-        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        closest_point: VectorLike[float] | None = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        **kwargs,
-    ) -> PointSet: ...
+    def connectivity(self: PointSet, extraction_mode: _ConnectivityMode = ..., variable_input: float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None = ..., scalar_range: VectorLike[float] | None = ..., scalars: str | None = ..., label_regions: bool = ..., region_assignment_mode: _RegionAssignmentMode = ..., region_ids: int | VectorLike[int] | None = ..., point_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., closest_point: VectorLike[float] | None = ..., inplace: bool = ..., progress_bar: bool = ..., **kwargs) -> PointSet: ...  # type: ignore[misc]  # noqa: E501, FBT001
     @overload
-    def connectivity(  # type: ignore[misc]
-        self: DataSet,
-        extraction_mode: _ConnectivityMode = ...,
-        variable_input: (
-            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
-        ) = ...,
-        scalar_range: VectorLike[float] | None = ...,
-        scalars: str | None = ...,
-        label_regions: bool = ...,  # noqa: FBT001
-        region_assignment_mode: _RegionAssignmentMode = ...,
-        region_ids: int | VectorLike[int] | None = ...,
-        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
-        closest_point: VectorLike[float] | None = ...,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-        **kwargs,
-    ) -> UnstructuredGrid: ...
+    def connectivity(self: DataSet, extraction_mode: _ConnectivityMode = ..., variable_input: float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None = ..., scalar_range: VectorLike[float] | None = ..., scalars: str | None = ..., label_regions: bool = ..., region_assignment_mode: _RegionAssignmentMode = ..., region_ids: int | VectorLike[int] | None = ..., point_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ..., closest_point: VectorLike[float] | None = ..., inplace: bool = ..., progress_bar: bool = ..., **kwargs) -> UnstructuredGrid: ...  # type: ignore[misc]  # noqa: E501, FBT001
+    # fmt: on
     @_deprecate_positional_args(allowed=['extraction_mode', 'variable_input'])
     def connectivity(  # type: ignore[misc]  # noqa: PLR0917
-        self: DataSet,
-        extraction_mode: _ConnectivityMode = 'all',
+        self: _DataSetType,
+        extraction_mode: Literal[
+            'all',
+            'largest',
+            'specified',
+            'cell_seed',
+            'point_seed',
+            'closest',
+        ] = 'all',
         variable_input: (
             float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
         ) = None,
         scalar_range: VectorLike[float] | None = None,
         scalars: str | None = None,
         label_regions: bool = True,  # noqa: FBT001, FBT002
-        region_assignment_mode: _RegionAssignmentMode = 'descending',
+        region_assignment_mode: Literal['ascending', 'descending', 'unspecified'] = 'descending',
         region_ids: int | VectorLike[int] | None = None,
         point_ids: int | VectorLike[int] | VectorLike[bool] | None = None,
         cell_ids: int | VectorLike[int] | VectorLike[bool] | None = None,
@@ -2772,27 +2730,17 @@ class DataSetFilters(DataObjectFilters):
         _warn_if_invalid_data(output)
         return output
 
+    # fmt: off
     @overload
-    def extract_largest(  # type: ignore[misc, overload-overlap]
-        self: PolyData,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> PolyData: ...
+    def extract_largest(self: PolyData, inplace: bool = ..., progress_bar: bool = ...) -> PolyData: ...  # type: ignore[misc, overload-overlap]  # noqa: E501, FBT001
     @overload
-    def extract_largest(  # type: ignore[misc, overload-overlap]
-        self: PointSet,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> PointSet: ...
+    def extract_largest(self: PointSet, inplace: bool = ..., progress_bar: bool = ...) -> PointSet: ...  # type: ignore[misc, overload-overlap]  # noqa: E501, FBT001
     @overload
-    def extract_largest(  # type: ignore[misc]
-        self: DataSet,
-        inplace: bool = ...,  # noqa: FBT001
-        progress_bar: bool = ...,  # noqa: FBT001
-    ) -> UnstructuredGrid: ...
+    def extract_largest(self: DataSet, inplace: bool = ..., progress_bar: bool = ...) -> UnstructuredGrid: ...  # type: ignore[misc]  # noqa: E501, FBT001
+    # fmt: on
     @_deprecate_positional_args
     def extract_largest(  # type: ignore[misc]
-        self: DataSet,
+        self: _DataSetType,
         inplace: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ):
@@ -2841,7 +2789,7 @@ class DataSetFilters(DataObjectFilters):
 
     @_deprecate_positional_args
     def split_bodies(  # type: ignore[misc]
-        self: DataSet,
+        self: _DataSetType,
         label: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ) -> MultiBlock:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -14,6 +14,7 @@ from typing import Literal
 from typing import NamedTuple
 from typing import cast
 from typing import get_args
+from typing import overload
 import warnings
 
 import numpy as np
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from pyvista import DataSet
     from pyvista import ImageData
     from pyvista import MultiBlock
+    from pyvista import PointSet
     from pyvista import PolyData
     from pyvista import RectilinearGrid
     from pyvista import UnstructuredGrid
@@ -71,6 +73,9 @@ if TYPE_CHECKING:
 
 
 _SelectInteriorPointsOptions = Literal['signed_distance', 'cell_locator']
+
+_ConnectivityMode = Literal['all', 'largest', 'specified', 'cell_seed', 'point_seed', 'closest']
+_RegionAssignmentMode = Literal['ascending', 'descending', 'unspecified']
 
 
 _CLIP_SURFACE_SCALARS = '__pyvista_clip_surface_distance'
@@ -2243,24 +2248,74 @@ class DataSetFilters(DataObjectFilters):
 
         return output
 
+    @overload
+    def connectivity(  # type: ignore[misc]
+        self: PolyData,
+        extraction_mode: _ConnectivityMode = ...,
+        variable_input: (
+            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
+        ) = ...,
+        scalar_range: VectorLike[float] | None = ...,
+        scalars: str | None = ...,
+        label_regions: bool = ...,  # noqa: FBT001
+        region_assignment_mode: _RegionAssignmentMode = ...,
+        region_ids: int | VectorLike[int] | None = ...,
+        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        closest_point: VectorLike[float] | None = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        **kwargs,
+    ) -> PolyData: ...
+    @overload
+    def connectivity(  # type: ignore[misc]
+        self: PointSet,
+        extraction_mode: _ConnectivityMode = ...,
+        variable_input: (
+            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
+        ) = ...,
+        scalar_range: VectorLike[float] | None = ...,
+        scalars: str | None = ...,
+        label_regions: bool = ...,  # noqa: FBT001
+        region_assignment_mode: _RegionAssignmentMode = ...,
+        region_ids: int | VectorLike[int] | None = ...,
+        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        closest_point: VectorLike[float] | None = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        **kwargs,
+    ) -> PointSet: ...
+    @overload
+    def connectivity(  # type: ignore[misc]
+        self: DataSet,
+        extraction_mode: _ConnectivityMode = ...,
+        variable_input: (
+            float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
+        ) = ...,
+        scalar_range: VectorLike[float] | None = ...,
+        scalars: str | None = ...,
+        label_regions: bool = ...,  # noqa: FBT001
+        region_assignment_mode: _RegionAssignmentMode = ...,
+        region_ids: int | VectorLike[int] | None = ...,
+        point_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        cell_ids: int | VectorLike[int] | VectorLike[bool] | None = ...,
+        closest_point: VectorLike[float] | None = ...,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+        **kwargs,
+    ) -> UnstructuredGrid: ...
     @_deprecate_positional_args(allowed=['extraction_mode', 'variable_input'])
     def connectivity(  # type: ignore[misc]  # noqa: PLR0917
-        self: _DataSetType,
-        extraction_mode: Literal[
-            'all',
-            'largest',
-            'specified',
-            'cell_seed',
-            'point_seed',
-            'closest',
-        ] = 'all',
+        self: DataSet,
+        extraction_mode: _ConnectivityMode = 'all',
         variable_input: (
             float | VectorLike[float] | VectorLike[int] | VectorLike[bool] | None
         ) = None,
         scalar_range: VectorLike[float] | None = None,
         scalars: str | None = None,
         label_regions: bool = True,  # noqa: FBT001, FBT002
-        region_assignment_mode: Literal['ascending', 'descending', 'unspecified'] = 'descending',
+        region_assignment_mode: _RegionAssignmentMode = 'descending',
         region_ids: int | VectorLike[int] | None = None,
         point_ids: int | VectorLike[int] | VectorLike[bool] | None = None,
         cell_ids: int | VectorLike[int] | VectorLike[bool] | None = None,
@@ -2399,9 +2454,9 @@ class DataSetFilters(DataObjectFilters):
         Returns
         -------
         pyvista.DataSet
-            Dataset with labeled connected regions. Return type is
-            ``pyvista.PolyData`` if input type is ``pyvista.PolyData`` and
-            ``pyvista.UnstructuredGrid`` otherwise.
+            Dataset with labeled connected regions. The return type matches the
+            input for :class:`~pyvista.PolyData` and :class:`~pyvista.PointSet`,
+            and is :class:`~pyvista.UnstructuredGrid` for any other input.
 
         See Also
         --------
@@ -2717,9 +2772,27 @@ class DataSetFilters(DataObjectFilters):
         _warn_if_invalid_data(output)
         return output
 
+    @overload
+    def extract_largest(  # type: ignore[misc, overload-overlap]
+        self: PolyData,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> PolyData: ...
+    @overload
+    def extract_largest(  # type: ignore[misc, overload-overlap]
+        self: PointSet,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> PointSet: ...
+    @overload
+    def extract_largest(  # type: ignore[misc]
+        self: DataSet,
+        inplace: bool = ...,  # noqa: FBT001
+        progress_bar: bool = ...,  # noqa: FBT001
+    ) -> UnstructuredGrid: ...
     @_deprecate_positional_args
     def extract_largest(  # type: ignore[misc]
-        self: _DataSetType,
+        self: DataSet,
         inplace: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ):
@@ -2768,10 +2841,10 @@ class DataSetFilters(DataObjectFilters):
 
     @_deprecate_positional_args
     def split_bodies(  # type: ignore[misc]
-        self: _DataSetType,
+        self: DataSet,
         label: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
-    ):
+    ) -> MultiBlock:
         """Find, label, and split connected bodies/volumes.
 
         This splits different connected bodies into blocks in a

--- a/tests/typing/cases/connectivity.py
+++ b/tests/typing/cases/connectivity.py
@@ -24,6 +24,7 @@ def point_set() -> pv.PointSet:
     return pv.PointSet(np.random.default_rng(0).random((10, 3)))
 
 
+# Only the input class decides the return type
 assert_types(poly().connectivity(), pv.PolyData)
 assert_types(point_set().connectivity(), pv.PointSet)
 assert_types(as_data_set().connectivity(), pv.UnstructuredGrid)
@@ -33,6 +34,7 @@ assert_types(examples.load_rectilinear().connectivity(), pv.UnstructuredGrid)
 assert_types(examples.load_structured().connectivity(), pv.UnstructuredGrid)
 assert_types(examples.load_explicit_structured().connectivity(), pv.UnstructuredGrid)
 
+# Every extraction mode, given positionally
 assert_types(poly().connectivity('all'), pv.PolyData)
 assert_types(poly().connectivity('largest'), pv.PolyData)
 assert_types(poly().connectivity('specified', 0), pv.PolyData)
@@ -40,6 +42,7 @@ assert_types(poly().connectivity('cell_seed', 0), pv.PolyData)
 assert_types(poly().connectivity('point_seed', 0), pv.PolyData)
 assert_types(poly().connectivity('closest', (0.0, 0.0, 0.0)), pv.PolyData)
 
+# The same modes by keyword, in each id form the filter accepts
 assert_types(poly().connectivity(extraction_mode='specified', region_ids=0), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='specified', region_ids=[0, 1]), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=0), pv.PolyData)
@@ -51,6 +54,7 @@ assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=np.zero
 assert_types(poly().connectivity(extraction_mode='closest', closest_point=(0.0, 0.0, 0.0)), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='closest', closest_point=np.zeros(3)), pv.PolyData)
 
+# Keywords which do not change the return type
 assert_types(poly().connectivity(scalar_range=(-1.0, 1.0)), pv.PolyData)
 assert_types(poly().connectivity(scalar_range=[-1.0, 1.0], scalars='Normals'), pv.PolyData)
 assert_types(poly().connectivity(scalar_range=np.array([-1.0, 1.0])), pv.PolyData)
@@ -63,9 +67,11 @@ assert_types(poly().connectivity(inplace=True), pv.PolyData)
 assert_types(poly().connectivity(inplace=False), pv.PolyData)
 assert_types(poly().connectivity(progress_bar=True), pv.PolyData)
 
+# A mode and a keyword together, for the two non-PolyData overloads
 assert_types(as_data_set().connectivity('largest', label_regions=False), pv.UnstructuredGrid)
 assert_types(point_set().connectivity('all', inplace=True), pv.PointSet)
 
+# extract_largest delegates to connectivity and keeps its return type
 assert_types(poly().extract_largest(), pv.PolyData)
 assert_types(point_set().extract_largest(), pv.PointSet)
 assert_types(as_data_set().extract_largest(), pv.UnstructuredGrid)
@@ -73,6 +79,7 @@ assert_types(examples.load_hexbeam().extract_largest(), pv.UnstructuredGrid)
 assert_types(poly().extract_largest(inplace=True), pv.PolyData)
 assert_types(poly().extract_largest(progress_bar=True), pv.PolyData)
 
+# split_bodies is a MultiBlock whatever the input
 assert_types(poly().split_bodies(), pv.MultiBlock)
 assert_types(as_data_set().split_bodies(), pv.MultiBlock)
 assert_types(examples.load_hexbeam().split_bodies(label=True), pv.MultiBlock)

--- a/tests/typing/cases/connectivity.py
+++ b/tests/typing/cases/connectivity.py
@@ -1,0 +1,84 @@
+"""Typing cases for :meth:`pyvista.DataSetFilters.connectivity` and its callers."""
+
+from __future__ import annotations
+
+import numpy as np
+from type_assert import assert_types
+
+import pyvista as pv
+from pyvista import examples
+
+
+def as_data_set() -> pv.DataSet:
+    """Return a grid typed only as the base class."""
+    return examples.load_hexbeam()
+
+
+def poly() -> pv.PolyData:
+    """Return two disconnected spheres."""
+    return pv.Sphere(center=(-4, 0, 0), phi_resolution=6, theta_resolution=6) + pv.Sphere(phi_resolution=6, theta_resolution=6)
+
+
+def point_set() -> pv.PointSet:
+    """Return a point cloud."""
+    return pv.PointSet(np.random.default_rng(0).random((10, 3)))
+
+
+assert_types(poly().connectivity(), pv.PolyData)
+assert_types(point_set().connectivity(), pv.PointSet)
+assert_types(as_data_set().connectivity(), pv.UnstructuredGrid)
+assert_types(examples.load_hexbeam().connectivity(), pv.UnstructuredGrid)
+assert_types(examples.load_uniform().connectivity(), pv.UnstructuredGrid)
+assert_types(examples.load_rectilinear().connectivity(), pv.UnstructuredGrid)
+assert_types(examples.load_structured().connectivity(), pv.UnstructuredGrid)
+assert_types(examples.load_explicit_structured().connectivity(), pv.UnstructuredGrid)
+
+assert_types(poly().connectivity('all'), pv.PolyData)
+assert_types(poly().connectivity('largest'), pv.PolyData)
+assert_types(poly().connectivity('specified', 0), pv.PolyData)
+assert_types(poly().connectivity('cell_seed', 0), pv.PolyData)
+assert_types(poly().connectivity('point_seed', 0), pv.PolyData)
+assert_types(poly().connectivity('closest', (0.0, 0.0, 0.0)), pv.PolyData)
+
+assert_types(poly().connectivity(extraction_mode='specified', region_ids=0), pv.PolyData)
+assert_types(poly().connectivity(extraction_mode='specified', region_ids=[0, 1]), pv.PolyData)
+assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=0), pv.PolyData)
+assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=[0, 1]), pv.PolyData)
+assert_types(
+    poly().connectivity(extraction_mode='cell_seed', cell_ids=np.zeros(96, dtype=bool)),
+    pv.PolyData,
+)
+assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=0), pv.PolyData)
+assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=[0, 1]), pv.PolyData)
+assert_types(
+    poly().connectivity(extraction_mode='point_seed', point_ids=np.zeros(52, dtype=bool)),
+    pv.PolyData,
+)
+assert_types(poly().connectivity(extraction_mode='closest', closest_point=(0.0, 0.0, 0.0)), pv.PolyData)
+assert_types(poly().connectivity(extraction_mode='closest', closest_point=np.zeros(3)), pv.PolyData)
+
+assert_types(poly().connectivity(scalar_range=(-1.0, 1.0)), pv.PolyData)
+assert_types(poly().connectivity(scalar_range=[-1.0, 1.0], scalars='Normals'), pv.PolyData)
+assert_types(poly().connectivity(scalar_range=np.array([-1.0, 1.0])), pv.PolyData)
+assert_types(poly().connectivity(label_regions=True), pv.PolyData)
+assert_types(poly().connectivity(label_regions=False), pv.PolyData)
+assert_types(poly().connectivity(region_assignment_mode='ascending'), pv.PolyData)
+assert_types(poly().connectivity(region_assignment_mode='descending'), pv.PolyData)
+assert_types(poly().connectivity(region_assignment_mode='unspecified'), pv.PolyData)
+assert_types(poly().connectivity(inplace=True), pv.PolyData)
+assert_types(poly().connectivity(inplace=False), pv.PolyData)
+assert_types(poly().connectivity(progress_bar=True), pv.PolyData)
+
+assert_types(as_data_set().connectivity('largest', label_regions=False), pv.UnstructuredGrid)
+assert_types(point_set().connectivity('all', inplace=True), pv.PointSet)
+
+assert_types(poly().extract_largest(), pv.PolyData)
+assert_types(point_set().extract_largest(), pv.PointSet)
+assert_types(as_data_set().extract_largest(), pv.UnstructuredGrid)
+assert_types(examples.load_hexbeam().extract_largest(), pv.UnstructuredGrid)
+assert_types(poly().extract_largest(inplace=True), pv.PolyData)
+assert_types(poly().extract_largest(progress_bar=True), pv.PolyData)
+
+assert_types(poly().split_bodies(), pv.MultiBlock)
+assert_types(as_data_set().split_bodies(), pv.MultiBlock)
+assert_types(examples.load_hexbeam().split_bodies(label=True), pv.MultiBlock)

--- a/tests/typing/cases/connectivity.py
+++ b/tests/typing/cases/connectivity.py
@@ -44,16 +44,10 @@ assert_types(poly().connectivity(extraction_mode='specified', region_ids=0), pv.
 assert_types(poly().connectivity(extraction_mode='specified', region_ids=[0, 1]), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=0), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=[0, 1]), pv.PolyData)
-assert_types(
-    poly().connectivity(extraction_mode='cell_seed', cell_ids=np.zeros(96, dtype=bool)),
-    pv.PolyData,
-)
+assert_types(poly().connectivity(extraction_mode='cell_seed', cell_ids=np.zeros(96, dtype=bool)), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=0), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=[0, 1]), pv.PolyData)
-assert_types(
-    poly().connectivity(extraction_mode='point_seed', point_ids=np.zeros(52, dtype=bool)),
-    pv.PolyData,
-)
+assert_types(poly().connectivity(extraction_mode='point_seed', point_ids=np.zeros(52, dtype=bool)), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='closest', closest_point=(0.0, 0.0, 0.0)), pv.PolyData)
 assert_types(poly().connectivity(extraction_mode='closest', closest_point=np.zeros(3)), pv.PolyData)
 


### PR DESCRIPTION
### Overview

Stacked on #9139 — merge that first.

`connectivity`, `extract_largest` and `split_bodies` all returned `Any`, so nothing downstream could tell a `PolyData` result from an `UnstructuredGrid` one. Overloads on `self` give each the return type its docstring already promised, which also turned up an inaccuracy worth fixing: `PointSet` input returns `PointSet`, not `UnstructuredGrid` as the `Returns` section claimed.

`tests/typing/cases/connectivity.py` covers every extraction mode, every keyword and every dataset class through `type-assert`, so the static and runtime types are checked against each other rather than separately. Two of the cases I first wrote disagreed between the halves, which is the point of running both.

- These are the first `@overload` declarations in `pyvista/core/filters/`; they follow the `wrap()` pattern, including the narrow `overload-overlap` ignores.
- The `Literal` for the extraction and region assignment modes is now a module alias, since the overloads repeat it four times.
- Rendered docs are unaffected — `overloads_location` in `conf.py` is a list, so no `@overload` renders anywhere today.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
