### PR TITLE
Fix reading the active array deciding what it will be

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -35,6 +35,15 @@ def sphere(rng):
 
 
 @pytest.fixture(scope='session')
+def unchosen_sphere(rng):
+    """Return a sphere whose active arrays are resolved per read, none having been chosen."""
+    mesh = pv.Sphere()
+    mesh.point_data['data'] = rng.random(mesh.n_points)
+    mesh.point_data['vec'] = rng.random((mesh.n_points, 3))
+    return mesh
+
+
+@pytest.fixture(scope='session')
 def big_sphere(rng):
     """Return a sphere large enough that array traffic dominates per-call overhead."""
     mesh = pv.Sphere(theta_resolution=200, phi_resolution=200)

--- a/benchmarks/test_attribute_access.py
+++ b/benchmarks/test_attribute_access.py
@@ -28,6 +28,16 @@ def test_active_scalars(sphere, benchmark):
     assert benchmark(operator.attrgetter('active_scalars'), sphere).size
 
 
+def test_active_scalars_info_unchosen(unchosen_sphere, benchmark):
+    """Read the active scalars info of a mesh whose active array was never chosen."""
+    assert benchmark(operator.attrgetter('active_scalars_info'), unchosen_sphere)
+
+
+def test_active_scalars_unchosen(unchosen_sphere, benchmark):
+    """Read the active scalars of a mesh whose active array was never chosen."""
+    assert benchmark(operator.attrgetter('active_scalars'), unchosen_sphere).size
+
+
 def test_active_vectors_info(sphere, benchmark):
     """Read the active vectors association and name."""
     assert benchmark(operator.attrgetter('active_vectors_info'), sphere) is not None

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -183,8 +183,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        If both cell and point scalars are present and neither has been set
-        active at the dataset level, the point scalars are reported.
+        If the point and cell attributes both have active scalars and neither
+        has been chosen at the dataset level, the point scalars are reported.
 
         Examples
         --------
@@ -215,7 +215,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
                     name = None
 
         if name is None:
-            # Resolved on every read, so an array activated later is still seen
+            # Search on every read so an array activated later is seen
             for association, attributes in (
                 (FieldAssociation.POINT, self.GetPointData()),
                 (FieldAssociation.CELL, self.GetCellData()),
@@ -242,8 +242,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        If both cell and point vectors are present and neither has been set
-        active at the dataset level, the point vectors are reported.
+        If the point and cell attributes both have active vectors and neither
+        has been chosen at the dataset level, the point vectors are reported.
 
         Examples
         --------
@@ -272,7 +272,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
                     name = None
 
         if name is None:
-            # Resolved on every read, so an array activated later is still seen
+            # Search on every read so an array activated later is seen
             for association, attributes in (
                 (FieldAssociation.POINT, self.GetPointData()),
                 (FieldAssociation.CELL, self.GetCellData()),
@@ -949,7 +949,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             Deep or shallow copy.
 
         """
-        # The private state throughout, so an unresolved active array stays unresolved
+        # Copy the private tuples, not the properties, which would resolve an unchosen array
         if deep:
             self._association_complex_names = _copy_association_names(
                 ido._association_complex_names

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -224,8 +224,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             ):
                 active_name = _active_scalars_name(attributes)
                 if active_name is not None:
-                    self._active_scalars_info = ActiveArrayInfoTuple(association, active_name)
-                    break
+                    # Returned, not recorded, so a later activation is still seen.
+                    return ActiveArrayInfoTuple(association, active_name)
 
         return self._active_scalars_info
 
@@ -283,8 +283,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             ):
                 name = _active_vectors_name(attributes)
                 if name is not None:
-                    self._active_vectors_info = ActiveArrayInfoTuple(association, name)
-                    break
+                    # Returned, not recorded, so a later activation is still seen.
+                    return ActiveArrayInfoTuple(association, name)
 
         return self._active_vectors_info
 
@@ -960,16 +960,17 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             self._association_bitarray_names = _copy_association_names(
                 ido._association_bitarray_names
             )
-            self._active_scalars_info = ido.active_scalars_info.copy()
-            self._active_vectors_info = ido.active_vectors_info.copy()
-            self._active_tensors_info = ido.active_tensors_info.copy()
+            # the private state, so an unresolved active array stays unresolved on the copy
+            self._active_scalars_info = ido._active_scalars_info.copy()
+            self._active_vectors_info = ido._active_vectors_info.copy()
+            self._active_tensors_info = ido._active_tensors_info.copy()
         else:
             # pass by reference
             self._association_complex_names = ido._association_complex_names
             self._association_bitarray_names = ido._association_bitarray_names
-            self._active_scalars_info = ido.active_scalars_info
-            self._active_vectors_info = ido.active_vectors_info
-            self._active_tensors_info = ido.active_tensors_info
+            self._active_scalars_info = ido._active_scalars_info
+            self._active_vectors_info = ido._active_vectors_info
+            self._active_tensors_info = ido._active_tensors_info
 
     @property
     def point_data(self: Self) -> DataSetAttributes:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -183,9 +183,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        If both cell and point scalars are present and neither have
-        been set active within at the dataset level, point scalars
-        will be made active.
+        If both cell and point scalars are present and neither has been set
+        active at the dataset level, the point scalars are reported.
 
         Examples
         --------
@@ -216,16 +215,15 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
                     name = None
 
         if name is None:
-            # check for the active scalars in point or cell arrays
-            self._active_scalars_info = ActiveArrayInfoTuple(field, None)
+            # Resolved on every read, so an array activated later is still seen
             for association, attributes in (
                 (FieldAssociation.POINT, self.GetPointData()),
                 (FieldAssociation.CELL, self.GetCellData()),
             ):
                 active_name = _active_scalars_name(attributes)
                 if active_name is not None:
-                    # Returned, not recorded, so a later activation is still seen.
                     return ActiveArrayInfoTuple(association, active_name)
+            return ActiveArrayInfoTuple(field, None)
 
         return self._active_scalars_info
 
@@ -244,9 +242,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        If both cell and point vectors are present and neither have
-        been set active within at the dataset level, point vectors
-        will be made active.
+        If both cell and point vectors are present and neither has been set
+        active at the dataset level, the point vectors are reported.
 
         Examples
         --------
@@ -275,16 +272,15 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
                     name = None
 
         if name is None:
-            # check for the active vectors in point or cell arrays
-            self._active_vectors_info = ActiveArrayInfoTuple(field, None)
+            # Resolved on every read, so an array activated later is still seen
             for association, attributes in (
                 (FieldAssociation.POINT, self.GetPointData()),
                 (FieldAssociation.CELL, self.GetCellData()),
             ):
                 name = _active_vectors_name(attributes)
                 if name is not None:
-                    # Returned, not recorded, so a later activation is still seen.
                     return ActiveArrayInfoTuple(association, name)
+            return ActiveArrayInfoTuple(field, None)
 
         return self._active_vectors_info
 
@@ -953,6 +949,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             Deep or shallow copy.
 
         """
+        # The private state throughout, so an unresolved active array stays unresolved
         if deep:
             self._association_complex_names = _copy_association_names(
                 ido._association_complex_names
@@ -960,7 +957,6 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             self._association_bitarray_names = _copy_association_names(
                 ido._association_bitarray_names
             )
-            # the private state, so an unresolved active array stays unresolved on the copy
             self._active_scalars_info = ido._active_scalars_info.copy()
             self._active_vectors_info = ido._active_vectors_info.copy()
             self._active_tensors_info = ido._active_tensors_info.copy()

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -259,6 +259,38 @@ def test_active_scalars_cell(hexbeam):
     assert hexbeam.active_scalars_info[1] == 'sample_cell_scalars'
 
 
+@pytest.mark.parametrize(
+    'observe',
+    [
+        lambda _mesh: None,
+        lambda mesh: mesh.active_scalars_info,
+        lambda mesh: mesh.active_vectors_info,
+        repr,
+        lambda mesh: mesh.copy(deep=True),
+        lambda mesh: mesh.copy(deep=False),
+    ],
+    ids=['nothing', 'scalars_info', 'vectors_info', 'repr', 'deep_copy', 'shallow_copy'],
+)
+def test_active_scalars_is_not_decided_by_reading_it(hexbeam, observe):
+    """Reading the active arrays must not decide which array a later one activates."""
+    observe(hexbeam)
+
+    hexbeam['new_point_array'] = np.ones((hexbeam.n_points, 3))
+
+    assert hexbeam.active_scalars_info.name == 'new_point_array'
+    assert hexbeam.active_scalars_info.association == pv.FieldAssociation.POINT
+
+
+def test_active_scalars_keeps_an_explicit_choice(hexbeam):
+    """An array chosen explicitly stays active when a new array is added."""
+    hexbeam.set_active_scalars('sample_cell_scalars', preference='cell')
+
+    hexbeam['new_point_array'] = np.ones(hexbeam.n_points)
+
+    assert hexbeam.active_scalars_info.name == 'sample_cell_scalars'
+    assert hexbeam.active_scalars_info.association == pv.FieldAssociation.CELL
+
+
 def test_field_data_bad_value(hexbeam):
     with pytest.raises(TypeError):
         hexbeam.field_data['new_array'] = None

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -308,6 +308,31 @@ def test_active_scalars_keeps_an_explicit_choice(hexbeam, deep):
         assert mesh.active_scalars_info.association == pv.FieldAssociation.CELL
 
 
+@pytest.mark.parametrize('deep', [True, False], ids=['deep', 'shallow'])
+def test_active_scalars_preference_survives_copy(hexbeam, deep):
+    """The preference between same-named arrays is copied, and the copy can change its own."""
+    hexbeam.point_data['data'] = np.arange(hexbeam.n_points)
+    hexbeam.cell_data['data'] = np.arange(hexbeam.n_cells)
+    hexbeam.set_active_scalars('data', preference='cell')
+
+    duplicate = hexbeam.copy(deep=deep)
+    assert duplicate.active_scalars_info.association == pv.FieldAssociation.CELL
+    duplicate.set_active_scalars('data', preference='point')
+
+    assert hexbeam.active_scalars_info.association == pv.FieldAssociation.CELL
+    assert hexbeam.active_scalars.shape == (hexbeam.n_cells,)
+    assert duplicate.active_scalars_info.association == pv.FieldAssociation.POINT
+    assert duplicate.active_scalars.shape == (duplicate.n_points,)
+
+
+def test_filter_output_resolves_its_own_active_scalars(hexbeam):
+    """A filter output resolves the array the filter activated when the input chose none."""
+    elevated = hexbeam.elevation()
+
+    assert elevated.active_scalars_info.name == 'Elevation'
+    assert elevated.active_scalars_info.association == pv.FieldAssociation.POINT
+
+
 def test_field_data_bad_value(hexbeam):
     with pytest.raises(TypeError):
         hexbeam.field_data['new_array'] = None

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -259,18 +259,17 @@ def test_active_scalars_cell(hexbeam):
     assert hexbeam.active_scalars_info[1] == 'sample_cell_scalars'
 
 
-@pytest.mark.parametrize(
-    'observe',
-    [
-        lambda _mesh: None,
-        lambda mesh: mesh.active_scalars_info,
-        lambda mesh: mesh.active_vectors_info,
-        repr,
-        lambda mesh: mesh.copy(deep=True),
-        lambda mesh: mesh.copy(deep=False),
-    ],
-    ids=['nothing', 'scalars_info', 'vectors_info', 'repr', 'deep_copy', 'shallow_copy'],
-)
+OBSERVATIONS = [
+    pytest.param(lambda _mesh: None, id='nothing'),
+    pytest.param(lambda mesh: mesh.active_scalars_info, id='scalars_info'),
+    pytest.param(lambda mesh: mesh.active_vectors_info, id='vectors_info'),
+    pytest.param(lambda mesh: mesh._repr_html_(), id='repr_html'),
+    pytest.param(lambda mesh: mesh.copy(deep=True), id='deep_copy'),
+    pytest.param(lambda mesh: mesh.copy(deep=False), id='shallow_copy'),
+]
+
+
+@pytest.mark.parametrize('observe', OBSERVATIONS)
 def test_active_scalars_is_not_decided_by_reading_it(hexbeam, observe):
     """Reading the active arrays must not decide which array a later one activates."""
     observe(hexbeam)
@@ -281,14 +280,32 @@ def test_active_scalars_is_not_decided_by_reading_it(hexbeam, observe):
     assert hexbeam.active_scalars_info.association == pv.FieldAssociation.POINT
 
 
-def test_active_scalars_keeps_an_explicit_choice(hexbeam):
-    """An array chosen explicitly stays active when a new array is added."""
-    hexbeam.set_active_scalars('sample_cell_scalars', preference='cell')
+@pytest.mark.parametrize('observe', OBSERVATIONS)
+def test_active_vectors_is_not_decided_by_reading_it(hexbeam, observe):
+    """The point vectors win over the cell vectors however late they are activated."""
+    hexbeam.cell_data['cell_vectors'] = np.ones((hexbeam.n_cells, 3))
+    hexbeam.cell_data.active_vectors_name = 'cell_vectors'
+    observe(hexbeam)
+
+    hexbeam.point_data['point_vectors'] = np.ones((hexbeam.n_points, 3))
+    hexbeam.point_data.active_vectors_name = 'point_vectors'
+
+    assert hexbeam.active_vectors_info.name == 'point_vectors'
+    assert hexbeam.active_vectors_info.association == pv.FieldAssociation.POINT
+    assert hexbeam.active_vectors.shape == (hexbeam.n_points, 3)
+
+
+@pytest.mark.parametrize('deep', [True, False], ids=['deep', 'shallow'])
+def test_active_scalars_keeps_an_explicit_choice(hexbeam, deep):
+    """An array chosen explicitly stays active when a new array is added, and is copied."""
+    hexbeam.set_active_scalars('sample_cell_scalars')
 
     hexbeam['new_point_array'] = np.ones(hexbeam.n_points)
+    duplicate = hexbeam.copy(deep=deep)
 
-    assert hexbeam.active_scalars_info.name == 'sample_cell_scalars'
-    assert hexbeam.active_scalars_info.association == pv.FieldAssociation.CELL
+    for mesh in (hexbeam, duplicate):
+        assert mesh.active_scalars_info.name == 'sample_cell_scalars'
+        assert mesh.active_scalars_info.association == pv.FieldAssociation.CELL
 
 
 def test_field_data_bad_value(hexbeam):
@@ -310,6 +327,8 @@ def test_copy_metadata(globe):
     """Ensure metadata is copied correctly."""
     globe.point_data['bitarray'] = np.zeros(globe.n_points, dtype=bool)
     globe.point_data['complex_data'] = np.zeros(globe.n_points, dtype=np.complex128)
+    # chosen, so the active-array assertions below compare a name rather than None
+    globe.set_active_scalars('bitarray')
 
     globe_shallow = globe.copy(deep=False)
     assert globe_shallow._active_scalars_info is globe._active_scalars_info


### PR DESCRIPTION
### Overview

`active_scalars_info` and `active_vectors_info` fall back to searching the point and cell attributes when no array has been chosen, and recorded what they found. That answer then served every later read, so an array activated afterwards was never seen — whether `mesh['vectors'] = ...` becomes the active scalars depended on whether anything had read the property first.

```python
mesh = examples.load_hexbeam()
mesh.active_scalars_info  # observing it is the bug
mesh['vectors'] = np.ones_like(mesh.points)
mesh.active_scalars_info.name  # 'sample_cell_scalars', not 'vectors'
```

`copy_meta_from` reads those properties, so `mesh.copy(deep=True)` with the result thrown away was enough to change how `mesh` behaved afterwards, and a later `mesh.glyph()` raises `Both scale and orient must use point data or cell data`. Every filter takes the same path through `_get_output`, so a filter's output inherited the input's resolved answer instead of resolving its own: `hexbeam.elevation()` reported and plotted `sample_cell_scalars` while `Elevation` was active in its point attributes. `copy_meta_from` now copies the private state, an unresolved array stays unresolved, and that output reports `Elevation`.

A fix rather than a breaking change: what the properties answer with no prior read is unchanged, the read-first path now agrees with it, and no mesh reports an array that a fresh mesh with the same attributes would not. It is an observable change wherever the recorded answer used to be served — a mesh read before an array was added, and every filter output whose input had no explicit choice — so a plot can change colour. That behaviour was never dependable, since `copy()`, `_repr_html_()` and filters all read these properties, and it contradicted the `Notes` on the properties themselves. Choosing an array explicitly with `set_active_scalars(name, preference=...)` is unaffected: still recorded, still wins, still survives a copy.

Reading is no longer a write, so resolving happens per read. That costs a search where nothing has been chosen and saves three property calls in every `copy`, which filters do on every `_get_output`. The first row compares against `main` serving its recorded answer; forced to search on every call, `main` takes 3.4 µs, so the search itself is cheaper here and the gap is the price of not caching. Caching against the attribute modification times would remove it but adds per-dataset state, so I left it out and added benchmarks covering the unresolved state instead.

| min per call, sphere | main | this branch |
| --- | --- | --- |
| `active_scalars_info`, nothing chosen | 1.67 µs | 2.45 µs |
| `active_vectors_info`, nothing chosen | 2.31 µs | 1.87 µs |
| `active_scalars_info`, chosen explicitly | 1.63 µs | 1.67 µs |
| `copy(deep=True)` | 24.5 µs | 19.3 µs |

Changes drafted by Claude Opus 5 and Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
