### PR TITLE
Run Vale without reviewdog

### DIFF
--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -124,38 +124,11 @@ jobs:
       - name: Install Vale Dependencies
         run: pip install 'docutils<0.22' 'sphinx-gallery<0.22.0'
 
-      # Convert .py examples to .rst so Vale can parse their headings.
-      - name: Extract example RST for Vale
-        run: python3 doc/extract_rst_from_py_for_vale.py examples .vale/examples
-
-      # Same, for docstrings, so Vale can check their prose too.
-      - name: Extract docstring RST for Vale
-        run: python3 doc/extract_rst_from_py_for_vale.py pyvista .vale/pyvista --mode docstrings
-
-      # `doc/run_vale.py` owns the path list; Vale runs here through the action
-      # instead, so that alerts appear inline on the pull request.
-      - name: Collect the paths Vale checks
-        id: vale-paths
-        run: echo "files=$(python3 doc/run_vale.py --print-files)" >> "$GITHUB_OUTPUT"
-
-      - name: "Run Vale"
-        uses: vale-cli/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
-        with:
-          files: ${{ steps.vale-paths.outputs.files }}
-          config: doc/.vale.ini
-          reporter: github-pr-check
-          filter_mode: nofilter
-          # Suggestion-level noise is filtered out by MinAlertLevel in doc/.vale.ini.
-          fail_level: warning
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # A heading in a scanned file has to pass, so nothing above would notice
-      # `Google.Headings` going slack. This runs Vale over a fixture of
-      # headings that must be flagged, and fails if any of them stops being.
+      # Pinned and checksummed rather than installed by `vale-action`, which
+      # downloads both Vale and reviewdog from GitHub releases on every run.
       - name: Install Vale
         run: |
-          curl -sSfL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -o vale.tar.gz
+          curl -sSfL --retry 5 --retry-delay 5 --retry-all-errors "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -o vale.tar.gz
           echo "${VALE_SHA256}  vale.tar.gz" | sha256sum --check
           sudo tar -xz -C /usr/local/bin -f vale.tar.gz vale
         env:
@@ -163,5 +136,8 @@ jobs:
           # From vale_<version>_checksums.txt on the release page; update both together.
           VALE_SHA256: a6f71a75a12fe689345b754f2412b90367fe33648abb7d200fa19eaadc2dbf6d
 
-      - name: "Check Vale still catches known-bad headings"
-        run: python3 tests/doc/vale/check_expected_failures.py
+      # Extracts the .rst Vale reads, lints every path, and checks that the rules
+      # still reject the fixtures in `tests/doc/vale`; `--annotate` reports each
+      # alert as an annotation on the pull request.
+      - name: Run Vale
+        run: python3 doc/run_vale.py --annotate

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -476,8 +476,8 @@ If you are on Linux or macOS, ``make docstyle`` runs the same script.
 
 ``doc/run_vale.py`` extracts the ``.rst`` files described below, runs Vale over
 every path CI checks, and then confirms that the rule still rejects the
-headings in ``tests/doc/vale/headings_invalid.rst``. The path list lives in
-that script alone; the workflow reads it with ``--print-files``.
+headings in ``tests/doc/vale/headings_invalid.rst``. CI runs that same script,
+so a local run checks exactly what the workflow does.
 
 Vale cannot parse prose written inside a Python file directly (for example,
 the ``# %%`` cell headings in a gallery example, or a docstring's

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -803,7 +803,7 @@ own for precision.
 - Sources have no input to preserve, so they subclass ``_Source``, which requests the
   precision in ``Update`` and casts in ``_update_and_wrap_output``. Return
   ``self._update_and_wrap_output()`` from a source's ``output`` property rather than
-  wrapping ``GetOutput()``, which is uncast.
+  wrapping ``GetOutput()``, whose points are not cast.
 - Geometry that PyVista builds without a VTK algorithm passes through
   ``_apply_points_dtype``.
 - Neither helper needs to know whether the algorithm supports double precision. The

--- a/doc/run_vale.py
+++ b/doc/run_vale.py
@@ -50,6 +50,10 @@ SOURCES = {'.vale/examples': 'examples', '.vale/pyvista': 'pyvista'}
 # GitHub has no `suggestion` level.
 LEVELS = {'error': 'error', 'warning': 'warning', 'suggestion': 'notice'}
 
+# A suggestion is advisory; anything above it fails the run. `MinAlertLevel` in
+# doc/.vale.ini decides which of them Vale reports in the first place.
+FAILING = {'warning', 'error'}
+
 
 def run(command: list[str]) -> int:
     """Echo and run ``command`` from the repository root."""
@@ -105,8 +109,14 @@ def lint(*, annotations: bool) -> int:
     alerts = json.loads(vale.stdout or '{}')
     annotate(alerts)
     total = sum(len(file_alerts) for file_alerts in alerts.values())
-    print(f'{total} alert(s) in {len(alerts)} file(s)')
-    return 1 if total else 0
+    failing = [
+        alert
+        for file_alerts in alerts.values()
+        for alert in file_alerts
+        if alert['Severity'] in FAILING
+    ]
+    print(f'{total} alert(s) in {len(alerts)} file(s), {len(failing)} of them failing')
+    return 1 if failing else 0
 
 
 def main() -> int:

--- a/doc/run_vale.py
+++ b/doc/run_vale.py
@@ -2,14 +2,12 @@
 
 The set of paths Vale checks is defined here and nowhere else: `make docstyle`,
 `CONTRIBUTING.rst` and the `Style and Docstring Check` workflow all reach it
-through this file, so adding a path is a one-line change. The workflow reads
-the list with ``--print-files`` rather than repeating it, because it runs Vale
-through `vale-action` to get inline annotations on the pull request.
+through this file, so adding a path is a one-line change.
 
 Usage::
 
-    python3 doc/run_vale.py                # extract, lint, check the fixtures
-    python3 doc/run_vale.py --print-files  # the path list, as JSON
+    python3 doc/run_vale.py             # extract, lint, check the fixtures
+    python3 doc/run_vale.py --annotate  # the same, with GitHub annotations
 """
 
 from __future__ import annotations
@@ -45,6 +43,13 @@ EXTRACT = [
     ['pyvista', '.vale/pyvista', '--mode', 'docstrings'],
 ]
 
+# An extracted file mirrors its source line for line, so an annotation can point
+# at the `.py` the reader has to edit rather than at the generated `.rst`.
+SOURCES = {'.vale/examples': 'examples', '.vale/pyvista': 'pyvista'}
+
+# GitHub has no `suggestion` level.
+LEVELS = {'error': 'error', 'warning': 'warning', 'suggestion': 'notice'}
+
 
 def run(command: list[str]) -> int:
     """Echo and run ``command`` from the repository root."""
@@ -52,19 +57,67 @@ def run(command: list[str]) -> int:
     return subprocess.run(command, cwd=ROOT, check=False).returncode
 
 
+def escape(value: str, *, is_property: bool = False) -> str:
+    """Escape ``value`` for a GitHub workflow command."""
+    escaped = value.replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+    if is_property:
+        escaped = escaped.replace(':', '%3A').replace(',', '%2C')
+    return escaped
+
+
+def source_of(path: str) -> str:
+    """Return the file an alert's reader has to edit, given the file Vale read."""
+    for extracted, source in SOURCES.items():
+        if path.startswith(extracted + '/'):
+            return source + path[len(extracted) : -len('.rst')] + '.py'
+    return path
+
+
+def annotate(alerts: dict[str, list[dict]]) -> None:
+    """Print one GitHub annotation per alert."""
+    for path, file_alerts in sorted(alerts.items()):
+        source = escape(source_of(path), is_property=True)
+        for alert in file_alerts:
+            level = LEVELS.get(alert['Severity'], 'error')
+            start, end = alert['Span']
+            title = escape(f'Vale: {alert["Check"]}', is_property=True)
+            print(
+                f'::{level} file={source},line={alert["Line"]},'
+                f'col={start},endColumn={end},title={title}'
+                f'::{escape(alert["Message"])}'
+            )
+
+
+def lint(*, annotations: bool) -> int:
+    """Run Vale over ``PATHS``; return an exit status."""
+    command = ['vale', '--config', str(CONFIG.relative_to(ROOT))]
+    if not annotations:
+        return run([*command, *PATHS])
+
+    command += ['--output=JSON', *PATHS]
+    print('+', ' '.join(command))
+    vale = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    print(vale.stderr, end='')
+    if vale.returncode > 1:  # Vale itself failed, and reported that instead of alerts
+        print(vale.stdout, end='')
+        return vale.returncode
+
+    alerts = json.loads(vale.stdout or '{}')
+    annotate(alerts)
+    total = sum(len(file_alerts) for file_alerts in alerts.values())
+    print(f'{total} alert(s) in {len(alerts)} file(s)')
+    return 1 if total else 0
+
+
 def main() -> int:
     """Extract, lint, and check the fixtures; return an exit status."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '--print-files',
+        '--annotate',
         action='store_true',
-        help='print the paths Vale checks as a JSON array, then exit',
+        help='report each alert as a GitHub Actions annotation',
     )
     args = parser.parse_args()
-
-    if args.print_files:
-        print(json.dumps(PATHS))
-        return 0
 
     if shutil.which('vale') is None:
         print("vale is not installed: pip install vale 'docutils<0.22' 'sphinx-gallery<0.22.0'")
@@ -75,7 +128,7 @@ def main() -> int:
         if code:
             return code
 
-    code = run(['vale', '--config', str(CONFIG.relative_to(ROOT)), *PATHS])
+    code = lint(annotations=args.annotate)
     if code:
         return code
 

--- a/doc/styles/Google/Headings.yml
+++ b/doc/styles/Google/Headings.yml
@@ -46,6 +46,7 @@ exceptions:
 
   # Terms that carry their own casing
   - ^bit\b # the `-bit` in `(64-bit)`
+  - ^dtype\b # NumPy's attribute name
   - ^glTF\b
   - ^mini\b # Apple's `Mac mini`
   - ^pytest\b

--- a/doc/styles/config/vocabularies/pyvista/accept.txt
+++ b/doc/styles/config/vocabularies/pyvista/accept.txt
@@ -248,6 +248,7 @@ docstrings
 doctest
 doctests
 doi
+dtype
 dunder
 eigen
 eigenmode

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1933,7 +1933,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and of the point, cell and
+        This will produce a deep copy of the points and of the point, cell, and
         field data of the original mesh.
 
         Examples
@@ -1973,7 +1973,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
 
         Notes
         -----
-        This will produce a deep copy of the points and of the point, cell and
+        This will produce a deep copy of the points and of the point, cell, and
         field data of the original mesh.
 
         Examples

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -144,7 +144,7 @@ def _convert_transform_input_to_float(
 
 
 def _copy_transformed_arrays(output: DataSet, filtered: DataObject, *, copy: bool) -> None:
-    """Copy the point, cell and field arrays the transform filter produced."""
+    """Copy the point, cell, and field arrays the transform filter produced."""
     output.point_data.update(filtered.point_data, copy=copy)
     output.cell_data.update(filtered.cell_data, copy=copy)
     output.field_data.update(filtered.field_data, copy=copy)
@@ -163,7 +163,7 @@ def _transform_rectilinear_axes(
     dataset: RectilinearGrid,
     components: tuple[NumpyArray[float], NumpyArray[float]],
 ) -> None:
-    """Set a grid's axes to another's, scaled and translated."""
+    """Scale and translate one grid's axes onto another."""
     # vtkTransformFilter returns a StructuredGrid, so the axes are transformed here instead
     translation, scale = components
     output.x = dataset.x * scale[0] + translation[0]


### PR DESCRIPTION
The Vale job installed both Vale and reviewdog from GitHub releases on every run, and a 504 on the reviewdog download failed the merge queue. It now installs the pinned, checksummed Vale build the job already downloaded for the fixture check and runs `doc/run_vale.py`, which reports each alert as a GitHub annotation from Vale's JSON output.

That turned up a second problem. `github-pr-check` needs `checks: write`, which this workflow's `permissions:` block does not grant, so reviewdog fell back to plain annotations and exited 0 no matter what `fail_level` said: the job was green while printing 31 `##[error]` lines. The first commit fixes that backlog, and #9130 merged another Oxford comma past the same gap while this PR was open — the last commit is that one, caught by the first run that actually enforces.

- No reviewdog, and one pinned download instead of two `latest` ones, with `curl --retry` over it.
- Alerts at `warning` and above fail, as `fail_level: warning` was meant to.
- Annotations point at the `.py` a docstring alert came from rather than the generated `.rst`.
- CI and `make docstyle` now run the same script, so `--print-files` is gone.

Resolves #9151

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
