### PR TITLE
Fix flaky mypy plugin test from a shared cache

### DIFF
--- a/tests/typing/mypy_plugin/test_plugin.py
+++ b/tests/typing/mypy_plugin/test_plugin.py
@@ -105,6 +105,9 @@ def _run_mypy_code(code, use_plugin, tmp_path):
         # A bare 'mypy' is on PATH only when the environment is activated.
         args = [sys.executable, '-m', 'mypy', '--show-traceback', '--follow-imports=skip']
 
+        # Cache to os.devnull so that runs in parallel do not share mypy's sqlite database
+        args.extend(['--cache-dir', os.devnull])
+
         # Set config file
         config = MYPY_CONFIG_FILE_USE_PLUGIN if use_plugin else MYPY_CONFIG_FILE_NO_PLUGIN
         args.extend(['--config-file', config])


### PR DESCRIPTION
### Overview

`test_promote_type_static` runs mypy in a subprocess from the project root and neither config file sets a cache directory, so all four cases write the same `.mypy_cache`. mypy 2 keeps that cache in sqlite and each independent process sets `journal_mode=WAL` on every shard, which SQLite refuses while another connection holds the database — and for that pragma it returns busy without consulting the busy handler, so there is no retry. Under `-n auto` two cases land on different workers and one dies with `sqlite3.OperationalError: database is locked`, as in [this macOS 3.14 job](https://github.com/pyvista/pyvista/actions/runs/34085350937/job/101633894842), where gw1 and gw2 started their cases three milliseconds apart. Which case loses is random.

Pointing the cache at `os.devnull` turns caching off for these runs, which is all the test needs. It also keeps them out of the repository's own `.mypy_cache`, which they were invalidating on every run by alternating the plugin and no-plugin configs.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
