### PR TITLE
Bump to `0.50.dev0` for the v0.49 release

### DIFF
--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -226,32 +226,31 @@ def _deprecate_positional_args(
                     s = 's'
                     this = 'these'
 
-                if not _is_deprecation_due(version):
-                    # Print warning
-                    version_str = '.'.join(map(str, version))
-                    arg_list = ', '.join(f'{a!r}' for a in offending_args)
-                    stack_level = 3
+                # Print warning
+                version_str = '.'.join(map(str, version))
+                arg_list = ', '.join(f'{a!r}' for a in offending_args)
+                stack_level = 3
 
-                    def call_site() -> str:
-                        # Get location where the function is called
-                        # Optimization: ``inspect.stack()`` reads source lines for every frame
-                        frame = sys._getframe(stack_level)
-                        file = Path(frame.f_code.co_filename).as_posix()
-                        return f'{file}:{frame.f_lineno}'
+                def call_site() -> str:
+                    # Get location where the function is called
+                    # Optimization: ``inspect.stack()`` reads source lines for every frame
+                    frame = sys._getframe(stack_level)
+                    file = Path(frame.f_code.co_filename).as_posix()
+                    return f'{file}:{frame.f_lineno}'
 
-                    def warn_positional_args() -> None:
-                        from pyvista.core.errors import PyVistaDeprecationWarning  # noqa: PLC0415
+                def warn_positional_args() -> None:
+                    from pyvista.core.errors import PyVistaDeprecationWarning  # noqa: PLC0415
 
-                        msg = (
-                            f'\n{call_site()}: '
-                            f'Argument{s} {arg_list} must be passed as{a}keyword argument{s} '
-                            f'to function {qualified_name()!r}.\n'
-                            f'From version {version_str}, passing {this} as{a}positional '
-                            f'argument{s} will result in a TypeError.'
-                        )
-                        warn_external(msg, PyVistaDeprecationWarning)
+                    msg = (
+                        f'\n{call_site()}: '
+                        f'Argument{s} {arg_list} must be passed as{a}keyword argument{s} '
+                        f'to function {qualified_name()!r}.\n'
+                        f'From version {version_str}, passing {this} as{a}positional '
+                        f'argument{s} will result in a TypeError.'
+                    )
+                    warn_external(msg, PyVistaDeprecationWarning)
 
-                    warn_positional_args()
+                warn_positional_args()
 
             return f(*args, **kwargs)
 

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -10,7 +10,7 @@ from typing import overload
 
 from typing_extensions import ParamSpec
 
-from pyvista._version import version_info
+from pyvista._version import _is_deprecation_due
 from pyvista._warn_external import warn_external
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ def _deprecate_positional_args(
             raise RuntimeError(msg)
 
         # Raise error post-deprecation
-        if version_info >= version:
+        if _is_deprecation_due(version):
             # Construct expected positional args and signature
             new_parameters = []
             max_args_to_print = actual_n_allowed + 2
@@ -226,7 +226,7 @@ def _deprecate_positional_args(
                     s = 's'
                     this = 'these'
 
-                if version_info < version:
+                if not _is_deprecation_due(version):
                     # Print warning
                     version_str = '.'.join(map(str, version))
                     arg_list = ', '.join(f'{a!r}' for a in offending_args)

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -16,7 +16,14 @@ Denotes the first release candidate.
 # major, minor, patch
 from __future__ import annotations
 
-version_info = 0, 49, 'dev0'
+version_info = 0, 50, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))
+
+
+def _is_deprecation_due(version: tuple[int, int]) -> bool:
+    """Check a release deadline, excluding its development versions."""
+    return version_info[:2] > version or (
+        version_info[:2] == version and not str(version_info[2]).startswith('dev')
+    )

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._version import _is_deprecation_due
 from pyvista._warn_external import warn_external
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.filters import _apply_points_dtype
@@ -238,7 +239,7 @@ class CompositeFilters(DataObjectFilters):
         """
         msg = '`extract_geometry` is deprecated. Use `extract_surface(algorithm=None)` instead.'
         warn_external(msg, PyVistaDeprecationWarning)
-        if pv.version_info >= (0, 50):  # pragma: no cover
+        if _is_deprecation_due((0, 50)):  # pragma: no cover
             msg = 'Convert this deprecation warning into an error.'
             raise RuntimeError(msg)
         if pv.version_info >= (0, 51):  # pragma: no cover

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -29,6 +29,7 @@ import pyvista_validation as _validation
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._version import _is_deprecation_due
 from pyvista._version import version_info
 from pyvista._warn_external import warn_external
 from pyvista.core._typing_core import _DataSetOrMultiBlockType
@@ -4525,7 +4526,7 @@ class DataObjectFilters:
 
         def warn_future():
             # Deprecated v0.47, convert to error in v0.50, remove v0.51
-            if pv.version_info >= (0, 50):  # pragma: no cover
+            if _is_deprecation_due((0, 50)):  # pragma: no cover
                 msg = (
                     'Convert this future warning into an error '
                     'and update the docstring default value to None.'

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -22,6 +22,7 @@ import pyvista_validation as _validation
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._version import _is_deprecation_due
 from pyvista._warn_external import warn_external
 from pyvista.core._vtk_utilities import vtk_version_info
 from pyvista.core.errors import AmbiguousDataError
@@ -1580,7 +1581,7 @@ class DataSetFilters(DataObjectFilters):
         """
         msg = '`extract_geometry` is deprecated. Use `extract_surface(algorithm=None)` instead.'
         warn_external(msg, PyVistaDeprecationWarning)
-        if pv.version_info >= (0, 50):  # pragma: no cover
+        if _is_deprecation_due((0, 50)):  # pragma: no cover
             msg = 'Convert this deprecation warning into an error.'
             raise RuntimeError(msg)
         if pv.version_info >= (0, 53):  # pragma: no cover
@@ -3167,7 +3168,7 @@ class DataSetFilters(DataObjectFilters):
         >>> pl.show()  # doctest:+SKIP
 
         """
-        if pv.version_info >= (0, 50):  # pragma: no cover
+        if _is_deprecation_due((0, 50)):  # pragma: no cover
             msg = 'Convert this deprecation warning into an error.'
             raise RuntimeError(msg)
         if pv.version_info >= (0, 51):  # pragma: no cover

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -18,6 +18,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._version import _is_deprecation_due
 from pyvista._warn_external import warn_external
 from pyvista.core._vtk_utilities import _SUPPORTS_POLYHEDRON_FACE_CELL_ARRAYS
 from pyvista.core._vtk_utilities import vtk_version_info
@@ -509,7 +510,7 @@ class PointSet(_PointSetBase, _vtk.vtkPointSet):
             '`extract_geometry` is deprecated. Use `extract_surface(algorithm=None)` instead.',
             PyVistaDeprecationWarning,
         )
-        if pv.version_info >= (0, 50):  # pragma: no cover
+        if _is_deprecation_due((0, 50)):  # pragma: no cover
             msg = 'Convert this deprecation warning into an error.'
             raise RuntimeError(msg)
         if pv.version_info >= (0, 53):  # pragma: no cover

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -34,6 +34,7 @@ from scipy.spatial.transform import Rotation
 from scooby.report import get_distribution_dependencies
 
 import pyvista as pv
+from pyvista import _version
 from pyvista import _vtk
 from pyvista import examples as ex
 from pyvista._deprecate_positional_args import _MAX_POSITIONAL_ARGS
@@ -3287,6 +3288,28 @@ def test_is_vtk_attribute_input_type(obj):
 
 
 warnings.simplefilter('always')
+
+
+@pytest.mark.parametrize('version', [(0, 49, 0), (0, 50, 'dev0'), (0, 50, 'dev1')])
+def test_deprecate_positional_args_before_deadline(monkeypatch, version):
+    monkeypatch.setattr(_version, 'version_info', version)
+
+    @_deprecate_positional_args(version=(0, 50))
+    def foo(bar):
+        return bar
+
+    with pytest.warns(pv.PyVistaDeprecationWarning, match='From version 0\\.50,'):
+        assert foo(True) is True
+
+
+@pytest.mark.parametrize('version', [(0, 50, '0rc1'), (0, 50, 0), (0, 51, 'dev0')])
+def test_deprecate_positional_args_at_deadline(monkeypatch, version):
+    monkeypatch.setattr(_version, 'version_info', version)
+
+    with pytest.raises(RuntimeError, match='Positional arguments are no longer allowed'):
+
+        @_deprecate_positional_args(version=(0, 50))
+        def foo(bar): ...
 
 
 def test_deprecate_positional_args_error_messages():

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -14,6 +14,7 @@ import pytest
 import pyvista as pv
 from pyvista import _vtk
 from pyvista import colors
+from pyvista._version import _is_deprecation_due
 from pyvista.examples.downloads import download_file
 import pyvista.plotting
 from pyvista.plotting._typing import ThemeOptions
@@ -545,7 +546,7 @@ def test_plotter_theme_attribute_setter():
     with pytest.raises(pv.core.errors.DeprecationError, match=match):
         pl.theme = my_theme
 
-    if pyvista.version_info >= (0, 50):  # pragma: no cover -- fires at the version bump
+    if _is_deprecation_due((0, 50)):  # pragma: no cover
         pytest.fail('Remove the `theme` setter')
 
 


### PR DESCRIPTION
### Overview

Prepare the v0.49.0 release by bumping the development version to `0.50.dev0`. Keep v0.50 deprecation reminders inactive during development prereleases, preserving positional-argument warnings and the existing v0.50 deadlines.

Testing with the version temporarily set to `0.49.0` found no deprecation warnings or errors that were not expected by unit testing.

Changes drafted by Codex, reviewed and understood by @akaszynski.
