### PR TITLE
Make `merge_points` mean point merging for every clip input

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3542,7 +3542,6 @@ class DataObjectFilters:
             source,
             _box_planes(bounds_),
             invert=invert,
-            merge_points=merge_points,
             progress_bar=progress_bar,
         )
 
@@ -5817,7 +5816,7 @@ def _keep_array_structure(
 
 def _weld_points(mesh: DataSet) -> DataSet:
     """Merge points that share a position exactly, leaving the cells alone."""
-    if isinstance(mesh, pv.PointSet) or not mesh.n_cells:
+    if not mesh.n_cells:
         return mesh
     alg = _vtk.vtkStaticCleanUnstructuredGrid()
     alg.SetInputData(
@@ -5835,7 +5834,6 @@ def _clip_by_box_planes(
     planes: Sequence[tuple[VectorLike[float], VectorLike[float]]],
     *,
     invert: bool,
-    merge_points: bool,
     progress_bar: bool,
 ) -> DataSet:
     """Clip by each plane in turn, keeping the inside or appending the outside pieces."""
@@ -5866,8 +5864,9 @@ def _clip_by_box_planes(
     if not outside:
         # Nothing lay outside the box
         return dataset.extract_cells([], pass_cell_ids=False, pass_point_ids=False)
+    # The pieces are merged afterwards if asked, in one pass with everything else
     append = _vtk.vtkAppendFilter()
-    append.SetMergePoints(merge_points)
+    append.MergePointsOff()
     for piece in outside:
         append.AddInputData(piece)
     _update_alg(append, progress_bar=progress_bar, message='Clipping a Dataset by a Bounding Box')

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3212,7 +3212,13 @@ class DataObjectFilters:
         )
         mesh_in = source.cast_to_poly_points() if apply_vtk_94x_patch else source
 
-        alg = _vtk.vtkTableBasedClipDataSet()
+        # vtkTableBasedClipDataSet keeps points that the input holds apart, but it does not
+        # support triangle strips and emits the points of a mesh that mixes them twice
+        alg: _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet = (
+            _vtk.vtkClipPolyData()
+            if isinstance(mesh_in, pv.PolyData) and mesh_in.n_strips
+            else _vtk.vtkTableBasedClipDataSet()
+        )
         alg.SetInputDataObject(mesh_in)  # Use the grid as the data we desire to cut
         alg.SetValue(value)
         # ``None`` clips by the active scalars instead, for a precomputed distance field
@@ -3394,29 +3400,23 @@ class DataObjectFilters:
 
         If no bounds are given, a corner of the dataset bounds will be removed.
 
-        A :class:`~pyvista.PolyData` is clipped with :vtk:`vtkBoxClipDataSet`, which splits
-        the cells the box cuts into simplices, and a :class:`~pyvista.PointSet` is clipped
-        the same way through its vertices. All other inputs,
-        that is :class:`~pyvista.ImageData`, :class:`~pyvista.RectilinearGrid`,
-        :class:`~pyvista.StructuredGrid`, :class:`~pyvista.ExplicitStructuredGrid`, and
-        :class:`~pyvista.UnstructuredGrid`, are clipped by the six box planes in turn with
-        the same clipper as :meth:`clip`, which keeps hexahedra and other cell types.
+        Every input is clipped by the six box planes in turn with the same clipper as
+        :meth:`clip`, so the cells the box does not cut keep their type. A
+        :class:`~pyvista.PointSet` is clipped through its vertices.
 
         .. versionchanged:: 0.49
 
-            - :class:`~pyvista.ImageData`, :class:`~pyvista.RectilinearGrid`,
-              :class:`~pyvista.StructuredGrid`, :class:`~pyvista.ExplicitStructuredGrid`, and
-              :class:`~pyvista.UnstructuredGrid` inputs are clipped by the six box planes
-              instead of :vtk:`vtkBoxClipDataSet`, so cells the box does not cut keep their
-              type instead of being split into tetrahedra, and the output normally has fewer
-              cells and points for the same clipped volume, whatever ``merge_points`` is.
-              Call :meth:`~pyvista.DataObjectFilters.triangulate` on the output for an
-              all-tetrahedra mesh as before.
+            - Every input is clipped by the six box planes instead of
+              :vtk:`vtkBoxClipDataSet`, so the cells the box does not cut keep their type
+              instead of being split into simplices, and the output normally has fewer
+              cells and points for the same clipped region. Call
+              :meth:`~pyvista.DataObjectFilters.triangulate` on the output for an
+              all-simplex mesh as before.
             - A :class:`~pyvista.PolyData` input gives a ``PolyData`` instead of an
-              :class:`~pyvista.UnstructuredGrid`, with the same points and cells.
+              :class:`~pyvista.UnstructuredGrid`.
             - ``merge_points`` merges points that share a position, or leaves them
-              apart, for every input class. It no longer gives each cell its own copy
-              of the points it shares with its neighbours; call
+              apart, for every input class. No input now gets a copy of every point per
+              cell; call
               :meth:`~pyvista.DataSetFilters.separate_cells` on the output for that.
 
         Parameters
@@ -3542,40 +3542,19 @@ class DataObjectFilters:
         if crinkle:
             source, active_scalars_info = _Crinkler._add_cell_ids(self)
 
-        # Optimization: vtkBoxClipDataSet splits every cell into tetrahedra (VTK 9.7), so
-        # ImageData, RectilinearGrid, StructuredGrid, ExplicitStructuredGrid, and
-        # UnstructuredGrid are clipped plane by plane instead, which keeps their cell types
-        # and is faster for it. PolyData, and the vertices a PointSet is clipped as, are
-        # already triangulated and gain nothing from it.
-        use_box_filter = isinstance(self, pv.PolyData)
-        if use_box_filter:
-            alg = _vtk.vtkBoxClipDataSet()
-            if not merge_points:
-                # vtkBoxClipDataSet uses vtkMergePoints by default
-                alg.SetLocator(_vtk.vtkNonMergingPointLocator())
-            alg.SetInputDataObject(source)
-            alg.SetBoxClip(*bounds_)
-            port = 0
-            if invert:
-                # invert the clip if needed
-                port = 1
-                alg.GenerateClippedOutputOn()
-            _update_alg(
-                alg, progress_bar=progress_bar, message='Clipping a Dataset by a Bounding Box'
-            )
-            clipped = _get_output(alg, oport=port)
-        else:
-            clipped = _clip_by_box_planes(
-                source,
-                _box_planes(bounds_),
-                invert=invert,
-                merge_points=merge_points,
-                progress_bar=progress_bar,
-            )
+        # Every class is clipped by the six box planes with the same clipper as ``clip``,
+        # which keeps the cell types the box does not cut
+        clipped = _clip_by_box_planes(
+            source,
+            _box_planes(bounds_, hold_off=isinstance(self, pv.PolyData)),
+            invert=invert,
+            merge_points=merge_points,
+            progress_bar=progress_bar,
+        )
 
         if crinkle:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
-        clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
+        clipped = _remove_unused_points_post_clip(clipped, self.bounds)
         if merge_points:
             clipped = _weld_points(clipped)
         return _keep_array_structure(_cast_output_to_match_input_type(clipped, self), self)
@@ -5800,10 +5779,20 @@ def _copy_active_attributes(source: DataSet, target: DataSet) -> None:
             attributes_out.SetActiveTensors(tensors.GetName())
 
 
-def _box_planes(bounds: NumpyArray[float]) -> list[tuple[VectorLike[float], VectorLike[float]]]:
+def _box_planes(
+    bounds: NumpyArray[float], *, hold_off: bool = False
+) -> list[tuple[VectorLike[float], VectorLike[float]]]:
     """Return the six ``(outward normal, origin)`` planes of a box clip specification."""
     if len(bounds) == 12:
         return [(bounds[i], bounds[i + 1]) for i in range(0, 12, 2)]
+    if hold_off:
+        # A clip drops a cell lying flat in its plane, so hold the planes off a surface
+        # by a fraction of the box to keep a face the box only touches
+        lengths = np.abs(bounds[1::2] - bounds[::2])
+        bounds = bounds.copy()
+        offset = 1e-9 * np.where(lengths > 0, lengths, 1.0)
+        bounds[::2] -= offset
+        bounds[1::2] += offset
     planes: list[tuple[VectorLike[float], VectorLike[float]]] = []
     for axis in range(3):
         for sign, bound in ((-1.0, bounds[2 * axis]), (1.0, bounds[2 * axis + 1])):
@@ -5819,7 +5808,13 @@ def _keep_array_structure(
     output: DataSet | MultiBlock, source: DataSet | MultiBlock
 ) -> DataSet | MultiBlock:
     """Give an empty clip the array names of its input, which VTK drops."""
-    if isinstance(output, pv.MultiBlock) or isinstance(source, pv.MultiBlock):
+    if isinstance(output, pv.MultiBlock):
+        for (ids, _, block), original in zip(
+            output.recursive_iterator('all', skip_none=True),
+            source.recursive_iterator(skip_none=True),
+            strict=True,
+        ):
+            output.replace(ids, _keep_array_structure(block, original))
         return output
     if not output.n_points:
         output.GetPointData().CopyStructure(source.GetPointData())

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -5883,17 +5883,15 @@ def _validate_clip_inplace(mesh: DataSet | MultiBlock) -> None:
         raise TypeError(msg)
 
 
-def _remove_unused_points_post_clip(clip_output, input_bounds, *, force: bool = False):
+def _remove_unused_points_post_clip(clip_output, input_bounds):
     # VTK clip filters are buggy and sometimes retain unused points from the input, e.g.:
     # https://github.com/pyvista/pyvista/issues/6511
     # https://github.com/pyvista/pyvista/issues/7738
 
     def maybe_remove_unused_points(mesh: DataSet):
         # Unused points are correctly removed sometimes, so for performance we only
-        # remove points when the clipped bounds match input bounds, or when the caller
-        # knows its filter always keeps them
-        needed = force or np.allclose(clip_output.bounds, input_bounds)
-        if needed and hasattr(mesh, 'remove_unused_points'):
+        # remove points when the clipped bounds match input bounds
+        if np.allclose(clip_output.bounds, input_bounds) and hasattr(mesh, 'remove_unused_points'):
             return mesh.remove_unused_points()
         return mesh
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3212,13 +3212,7 @@ class DataObjectFilters:
         )
         mesh_in = source.cast_to_poly_points() if apply_vtk_94x_patch else source
 
-        if isinstance(mesh_in, pv.PolyData):
-            alg: _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet = _vtk.vtkClipPolyData()
-        # elif isinstance(self, vtk.vtkImageData):
-        #     alg = vtk.vtkClipVolume()
-        #     alg.SetMixed3DCellGeneration(True)
-        else:
-            alg = _vtk.vtkTableBasedClipDataSet()
+        alg = _vtk.vtkTableBasedClipDataSet()
         alg.SetInputDataObject(mesh_in)  # Use the grid as the data we desire to cut
         alg.SetValue(value)
         # ``None`` clips by the active scalars instead, for a precomputed distance field
@@ -3232,12 +3226,12 @@ class DataObjectFilters:
             return in_.cast_to_pointset() if apply_vtk_94x_patch else in_
 
         if return_clipped:
-            a = _get_output(alg, oport=0)
-            b = _get_output(alg, oport=1)
+            a = _keep_array_structure(_get_output(alg, oport=0), source)
+            b = _keep_array_structure(_get_output(alg, oport=1), source)
             if crinkle:
                 a, b = _Crinkler._extract_crinkle_cells(source, a, b, active_scalars_info)
             return _maybe_cast_to_point_set(a), _maybe_cast_to_point_set(b)
-        clipped = _get_output(alg)
+        clipped = _keep_array_structure(_get_output(alg), source)
         if crinkle:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
         return _maybe_cast_to_point_set(clipped)
@@ -3262,6 +3256,13 @@ class DataObjectFilters:
 
         If no parameters are given, the clip will occur in the center
         of the dataset along the x-axis.
+
+        .. versionchanged:: 0.49
+
+            Points that a :class:`~pyvista.PolyData` input keeps apart are no longer
+            merged, so a surface with coincident points is clipped without losing them.
+            The output has slightly more points where the clip surface passes exactly
+            through a point shared by several cells.
 
         Parameters
         ----------
@@ -3360,15 +3361,15 @@ class DataObjectFilters:
         input_bounds = self.bounds
         if isinstance(result, tuple):
             result = (
-                _cast_output_to_match_input_type(result[0], self),
-                _cast_output_to_match_input_type(result[1], self),
+                _keep_array_structure(_cast_output_to_match_input_type(result[0], self), self),
+                _keep_array_structure(_cast_output_to_match_input_type(result[1], self), self),
             )
             result = (
                 _remove_unused_points_post_clip(result[0], input_bounds),
                 _remove_unused_points_post_clip(result[1], input_bounds),
             )
         else:
-            result = _cast_output_to_match_input_type(result, self)
+            result = _keep_array_structure(_cast_output_to_match_input_type(result, self), self)
             result = _remove_unused_points_post_clip(result, input_bounds)
         if inplace:
             if return_clipped:
@@ -3413,6 +3414,10 @@ class DataObjectFilters:
               all-tetrahedra mesh as before.
             - A :class:`~pyvista.PolyData` input gives a ``PolyData`` instead of an
               :class:`~pyvista.UnstructuredGrid`, with the same points and cells.
+            - ``merge_points`` merges points that share a position, or leaves them
+              apart, for every input class. It no longer gives each cell its own copy
+              of the points it shares with its neighbours; call
+              :meth:`~pyvista.DataSetFilters.separate_cells` on the output for that.
 
         Parameters
         ----------
@@ -3437,10 +3442,8 @@ class DataObjectFilters:
             Display a progress bar to indicate progress.
 
         merge_points : bool, default: True
-            If ``True``, coinciding points of independently defined mesh
-            elements will be merged. It has no effect on the inputs clipped by
-            the box planes when ``invert=False``, which produce no coinciding
-            points to merge.
+            If ``True``, points that share a position are merged into one.
+            If ``False``, points the input kept apart stay apart.
 
         crinkle : bool, default: False
             Crinkle the clip by extracting the entire cells along the
@@ -3573,7 +3576,9 @@ class DataObjectFilters:
         if crinkle:
             clipped = _Crinkler._extract_crinkle_cells(source, clipped, None, active_scalars_info)
         clipped = _remove_unused_points_post_clip(clipped, self.bounds, force=use_box_filter)
-        return _cast_output_to_match_input_type(clipped, self)
+        if merge_points:
+            clipped = _weld_points(clipped)
+        return _keep_array_structure(_cast_output_to_match_input_type(clipped, self), self)
 
     def clip_slab(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,
@@ -3700,7 +3705,7 @@ class DataObjectFilters:
         )
 
         input_bounds = self.bounds
-        result = _cast_output_to_match_input_type(result, self)
+        result = _keep_array_structure(_cast_output_to_match_input_type(result, self), self)
         return _remove_unused_points_post_clip(result, input_bounds)
 
     @_deprecate_positional_args(allowed=['implicit_function'])
@@ -5808,6 +5813,33 @@ def _box_planes(bounds: NumpyArray[float]) -> list[tuple[VectorLike[float], Vect
             origin[axis] = bound
             planes.append((normal, origin))
     return planes
+
+
+def _keep_array_structure(
+    output: DataSet | MultiBlock, source: DataSet | MultiBlock
+) -> DataSet | MultiBlock:
+    """Give an empty clip the array names of its input, which VTK drops."""
+    if isinstance(output, pv.MultiBlock) or isinstance(source, pv.MultiBlock):
+        return output
+    if not output.n_points:
+        output.GetPointData().CopyStructure(source.GetPointData())
+        output.GetCellData().CopyStructure(source.GetCellData())
+    return output
+
+
+def _weld_points(mesh: DataSet) -> DataSet:
+    """Merge points that share a position exactly, leaving the cells alone."""
+    if isinstance(mesh, pv.PointSet) or not mesh.n_cells:
+        return mesh
+    alg = _vtk.vtkStaticCleanUnstructuredGrid()
+    alg.SetInputData(
+        mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
+    )
+    alg.ToleranceIsAbsoluteOn()
+    alg.SetAbsoluteTolerance(0.0)
+    alg.RemoveUnusedPointsOn()
+    alg.Update()
+    return _get_output(alg)
 
 
 def _clip_by_box_planes(

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3260,9 +3260,9 @@ class DataObjectFilters:
         .. versionchanged:: 0.49
 
             Points that a :class:`~pyvista.PolyData` input keeps apart are no longer
-            merged, so a surface with coincident points is clipped without losing them.
-            The output has slightly more points where the clip surface passes exactly
-            through a point shared by several cells.
+            merged, unless it holds triangle strips, so a surface with coincident points
+            is clipped without losing them. The output has slightly more points where the
+            clip surface passes exactly through a point shared by several cells.
 
         Parameters
         ----------
@@ -3437,7 +3437,8 @@ class DataObjectFilters:
 
         merge_points : bool, default: True
             If ``True``, points that share a position are merged into one.
-            If ``False``, points the input kept apart stay apart.
+            If ``False``, points the input kept apart stay apart, unless a
+            :class:`~pyvista.PolyData` holds triangle strips.
 
         crinkle : bool, default: False
             Crinkle the clip by extracting the entire cells along the
@@ -3572,6 +3573,11 @@ class DataObjectFilters:
         :meth:`slice`.
 
         .. versionadded:: 0.48
+
+        .. versionchanged:: 0.49
+
+            Points that a :class:`~pyvista.PolyData` input keeps apart are no longer
+            merged, unless it holds triangle strips.
 
         Parameters
         ----------

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3212,13 +3212,7 @@ class DataObjectFilters:
         )
         mesh_in = source.cast_to_poly_points() if apply_vtk_94x_patch else source
 
-        # vtkTableBasedClipDataSet keeps points that the input holds apart, but it does not
-        # support triangle strips and emits the points of a mesh that mixes them twice
-        alg: _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet = (
-            _vtk.vtkClipPolyData()
-            if isinstance(mesh_in, pv.PolyData) and mesh_in.n_strips
-            else _vtk.vtkTableBasedClipDataSet()
-        )
+        alg = _clipper(mesh_in)
         alg.SetInputDataObject(mesh_in)  # Use the grid as the data we desire to cut
         alg.SetValue(value)
         # ``None`` clips by the active scalars instead, for a precomputed distance field
@@ -5802,6 +5796,15 @@ def _box_planes(
             origin[axis] = bound
             planes.append((normal, origin))
     return planes
+
+
+def _clipper(mesh: DataSet | MultiBlock) -> _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet:
+    """Return the clipper that keeps the points a mesh holds apart."""
+    # vtkTableBasedClipDataSet does not support triangle strips and duplicates the points
+    # of a mesh that mixes them with other cells
+    if isinstance(mesh, pv.PolyData) and mesh.n_strips:
+        return _vtk.vtkClipPolyData()
+    return _vtk.vtkTableBasedClipDataSet()
 
 
 def _keep_array_structure(

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3210,7 +3210,7 @@ class DataObjectFilters:
             and pv.vtk_version_info >= (9, 4)
             and pv.vtk_version_info < (9, 5)
         )
-        mesh_in = source.cast_to_poly_points() if apply_vtk_94x_patch else source
+        mesh_in = source.cast_to_poly_points() if apply_vtk_94x_patch else _clip_input(source)
 
         alg = _clipper(mesh_in)
         alg.SetInputDataObject(mesh_in)  # Use the grid as the data we desire to cut
@@ -5800,6 +5800,16 @@ def _clipper(mesh: DataSet | MultiBlock) -> _vtk.vtkClipPolyData | _vtk.vtkTable
     if isinstance(mesh, pv.PolyData) and mesh.n_strips:
         return _vtk.vtkClipPolyData()
     return _vtk.vtkTableBasedClipDataSet()
+
+
+def _clip_input(mesh: DataSet | MultiBlock) -> DataSet | MultiBlock:
+    """Return the mesh as a class the table-based clipper clips without tetrahedralizing."""
+    if isinstance(mesh, pv.ExplicitStructuredGrid) and pv.vtk_version_info < (9, 5):
+        grid = mesh.cast_to_unstructured_grid()
+        for name in set(grid.cell_data.keys()) - set(mesh.cell_data.keys()):
+            grid.cell_data.remove(name)
+        return grid
+    return mesh
 
 
 def _keep_array_structure(

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3519,7 +3519,7 @@ class DataObjectFilters:
             )
 
         if isinstance(self, pv.PointSet):
-            # vtkBoxClipDataSet clips cells, and a PointSet has none, so clip its vertices
+            # A PointSet has no cells to clip, so clip its vertices
             return (
                 self.cast_to_poly_points()
                 .clip_box(
@@ -3540,7 +3540,7 @@ class DataObjectFilters:
         # which keeps the cell types the box does not cut
         clipped = _clip_by_box_planes(
             source,
-            _box_planes(bounds_, hold_off=isinstance(self, pv.PolyData)),
+            _box_planes(bounds_),
             invert=invert,
             merge_points=merge_points,
             progress_bar=progress_bar,
@@ -5773,20 +5773,10 @@ def _copy_active_attributes(source: DataSet, target: DataSet) -> None:
             attributes_out.SetActiveTensors(tensors.GetName())
 
 
-def _box_planes(
-    bounds: NumpyArray[float], *, hold_off: bool = False
-) -> list[tuple[VectorLike[float], VectorLike[float]]]:
+def _box_planes(bounds: NumpyArray[float]) -> list[tuple[VectorLike[float], VectorLike[float]]]:
     """Return the six ``(outward normal, origin)`` planes of a box clip specification."""
     if len(bounds) == 12:
         return [(bounds[i], bounds[i + 1]) for i in range(0, 12, 2)]
-    if hold_off:
-        # A clip drops a cell lying flat in its plane, so hold the planes off a surface
-        # by a fraction of the box to keep a face the box only touches
-        lengths = np.abs(bounds[1::2] - bounds[::2])
-        bounds = bounds.copy()
-        offset = 1e-9 * np.where(lengths > 0, lengths, 1.0)
-        bounds[::2] -= offset
-        bounds[1::2] += offset
     planes: list[tuple[VectorLike[float], VectorLike[float]]] = []
     for axis in range(3):
         for sign, bound in ((-1.0, bounds[2 * axis]), (1.0, bounds[2 * axis + 1])):
@@ -5851,27 +5841,31 @@ def _clip_by_box_planes(
     """Clip by each plane in turn, keeping the inside or appending the outside pieces."""
     # Each plane keeps the box side of the mesh; with ``invert`` the pieces cut away are
     # collected and appended instead
+    # A clip keeps the side its normal points to, boundary included, so clipping from the
+    # inside keeps a cell lying flat in a box plane
     inside: DataSet = dataset
     outside = []
     for normal, origin in planes:
-        result = inside.clip(
-            normal=normal,
-            origin=origin,
-            invert=True,
-            return_clipped=invert,
-            progress_bar=progress_bar,
-        )
+        inward = -np.asarray(normal, dtype=float)
         if invert:
-            inside, piece = result
+            inside, piece = inside.clip(
+                normal=inward,
+                origin=origin,
+                invert=False,
+                return_clipped=True,
+                progress_bar=progress_bar,
+            )
             if piece.n_cells:
                 outside.append(piece)
         else:
-            inside = result
+            inside = inside.clip(
+                normal=inward, origin=origin, invert=False, progress_bar=progress_bar
+            )
     if not invert:
         return inside
     if not outside:
-        # Nothing lay outside the box, so return an empty clip of the right type
-        return inside.clip(normal=planes[0][0], origin=planes[0][1], invert=False)
+        # Nothing lay outside the box
+        return dataset.extract_cells([], pass_cell_ids=False, pass_point_ids=False)
     append = _vtk.vtkAppendFilter()
     append.SetMergePoints(merge_points)
     for piece in outside:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -810,11 +810,12 @@ class DataSetFilters(DataObjectFilters):
             'DataSet',
             _keep_array_structure(_cast_output_to_match_input_type(_get_output(alg), self), self),
         )
+        if not is_single_value:
+            # Keep what lies above the lower value as well
+            result0 = result0.clip_scalar(scalars=scalars, invert=False, value=lower)
         if inplace:
             self.copy_from(result0, deep=False)
             result0 = self
-        if not is_single_value:
-            return result0.clip_scalar(scalars=scalars, invert=False, value=lower, inplace=inplace)
         if both:
             result1 = cast(
                 'DataSet',

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -660,6 +660,11 @@ class DataSetFilters(DataObjectFilters):
     ):
         """Clip a dataset by a scalar.
 
+        .. versionchanged:: 0.49
+
+            Points that a :class:`~pyvista.PolyData` input keeps apart are no longer
+            merged, unless it holds triangle strips.
+
         Parameters
         ----------
         scalars : str, optional
@@ -797,6 +802,11 @@ class DataSetFilters(DataObjectFilters):
         crinkle: bool = False,  # noqa: FBT001, FBT002
     ):
         """Clip any mesh type using a :class:`pyvista.PolyData` surface mesh.
+
+        .. versionchanged:: 0.49
+
+            Points that a :class:`~pyvista.PolyData` input keeps apart are no longer
+            merged, unless it holds triangle strips.
 
         The clipped mesh type matches the input type for :class:`~pyvista.PointSet` and
         :class:`~pyvista.PolyData`, otherwise the output type is

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -782,10 +782,6 @@ class DataSetFilters(DataObjectFilters):
                     _cast_output_to_match_input_type(_get_output(alg, oport=1), self), self
                 ),
             )
-            if isinstance(self, _vtk.vtkPolyData):
-                # For some reason vtkClipPolyData with SetGenerateClippedOutput on
-                # leaves unreferenced vertices
-                result0, result1 = (r.clean() for r in (result0, result1))  # type: ignore[unreachable]
             return result0, result1
         return result0
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -35,6 +35,7 @@ from pyvista.core.filters import _match_points_dtype
 from pyvista.core.filters import _update_alg
 from pyvista.core.filters.data_object import DataObjectFilters
 from pyvista.core.filters.data_object import _cast_output_to_match_input_type
+from pyvista.core.filters.data_object import _clip_input
 from pyvista.core.filters.data_object import _clipper
 from pyvista.core.filters.data_object import _keep_array_structure
 from pyvista.core.filters.data_object import _validate_clip_inplace
@@ -761,7 +762,7 @@ class DataSetFilters(DataObjectFilters):
                 msg = 'Cannot have both=True for a range clip'
                 raise ValueError(msg)
         # Activate the scalars on a shallow copy so the input's active scalars are untouched
-        source = self.copy(deep=False)
+        source = cast('DataSet', _clip_input(self)).copy(deep=False)
         if scalars is None:
             set_default_active_scalars(source)
         else:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -35,6 +35,7 @@ from pyvista.core.filters import _match_points_dtype
 from pyvista.core.filters import _update_alg
 from pyvista.core.filters.data_object import DataObjectFilters
 from pyvista.core.filters.data_object import _cast_output_to_match_input_type
+from pyvista.core.filters.data_object import _clipper
 from pyvista.core.filters.data_object import _keep_array_structure
 from pyvista.core.filters.data_object import _validate_clip_inplace
 from pyvista.core.utilities.arrays import FieldAssociation
@@ -741,7 +742,7 @@ class DataSetFilters(DataObjectFilters):
         """
         if inplace:
             _validate_clip_inplace(self)
-        alg = _vtk.vtkTableBasedClipDataSet()
+        alg = _clipper(self)
 
         if is_single_value := isinstance(value, (float, int)):
             alg.SetValue(value)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -35,6 +35,7 @@ from pyvista.core.filters import _match_points_dtype
 from pyvista.core.filters import _update_alg
 from pyvista.core.filters.data_object import DataObjectFilters
 from pyvista.core.filters.data_object import _cast_output_to_match_input_type
+from pyvista.core.filters.data_object import _keep_array_structure
 from pyvista.core.filters.data_object import _validate_clip_inplace
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
@@ -740,10 +741,7 @@ class DataSetFilters(DataObjectFilters):
         """
         if inplace:
             _validate_clip_inplace(self)
-        if isinstance(self, _vtk.vtkPolyData):
-            alg: _vtk.vtkClipPolyData | _vtk.vtkTableBasedClipDataSet = _vtk.vtkClipPolyData()  # type: ignore[unreachable]
-        else:
-            alg = _vtk.vtkTableBasedClipDataSet()
+        alg = _vtk.vtkTableBasedClipDataSet()
 
         if is_single_value := isinstance(value, (float, int)):
             alg.SetValue(value)
@@ -768,14 +766,22 @@ class DataSetFilters(DataObjectFilters):
         alg.SetGenerateClippedOutput(both)
 
         _update_alg(alg, progress_bar=progress_bar, message='Clipping by a Scalar')
-        result0 = _get_output(alg)
+        result0 = cast(
+            'DataSet',
+            _keep_array_structure(_cast_output_to_match_input_type(_get_output(alg), self), self),
+        )
         if inplace:
             self.copy_from(result0, deep=False)
             result0 = self
         if not is_single_value:
             return result0.clip_scalar(scalars=scalars, invert=False, value=lower, inplace=inplace)
         if both:
-            result1 = _get_output(alg, oport=1)
+            result1 = cast(
+                'DataSet',
+                _keep_array_structure(
+                    _cast_output_to_match_input_type(_get_output(alg, oport=1), self), self
+                ),
+            )
             if isinstance(self, _vtk.vtkPolyData):
                 # For some reason vtkClipPolyData with SetGenerateClippedOutput on
                 # leaves unreferenced vertices
@@ -908,7 +914,10 @@ class DataSetFilters(DataObjectFilters):
             info = self.active_scalars_info
             if info.name is not None and not clipped.is_empty:
                 clipped.set_active_scalars(info.name, preference=info.association)
-        return _cast_output_to_match_input_type(clipped, self)
+        return cast(
+            'DataSet',
+            _keep_array_structure(_cast_output_to_match_input_type(clipped, self), self),
+        )
 
     @_deprecate_positional_args(allowed=['value'])
     def threshold(  # type: ignore[misc]  # noqa: PLR0917

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -256,7 +256,10 @@ def _cell_type_meshes():
     meshes = {
         'PolyData triangles': pv.Sphere(theta_resolution=8, phi_resolution=8),
         'PolyData quads': pv.Plane(i_resolution=3, j_resolution=3),
-        'PolyData lines': pv.Line((-1, 0, 0), (1, 0, 0), resolution=4),
+        'PolyData lines': pv.PolyData(
+            np.array([[x, 0.0, 0.0] for x in np.linspace(-1.0, 1.0, 5)]),
+            lines=[2, 0, 1, 2, 1, 2, 2, 2, 3, 2, 3, 4],
+        ),
         'PolyData verts': pv.PolyData(np.random.default_rng(0).uniform(-1, 1, (12, 3))),
         'ImageData': image,
         'RectilinearGrid': pv.RectilinearGrid(axis, axis, axis),
@@ -326,19 +329,25 @@ def test_clip_keeps_the_points_it_does_not_cut(mesh_type, name):
 def test_clip_splits_the_mesh_in_two(mesh_type, name):
     """What a clip keeps and what it removes add up to the whole mesh."""
     mesh = _cell_type_meshes()[mesh_type]
-    surface = pv.Sphere(radius=0.7, center=mesh.center, theta_resolution=16, phi_resolution=16)
+    center = np.array(mesh.center)
+    surface = pv.Sphere(
+        radius=0.6,
+        center=(center[0] + 0.3, center[1], center[2]),
+        theta_resolution=16,
+        phi_resolution=16,
+    )
     kept, removed = {
         'clip': lambda: (
-            mesh.clip(normal='z', origin=mesh.center, invert=False),
-            mesh.clip(normal='z', origin=mesh.center, invert=True),
+            mesh.clip(normal='x', origin=center, invert=False),
+            mesh.clip(normal='x', origin=center, invert=True),
         ),
         'clip_box': lambda: (
             mesh.clip_box([-0.4, 0.4] * 3, invert=False),
             mesh.clip_box([-0.4, 0.4] * 3, invert=True),
         ),
         'clip_slab': lambda: (
-            mesh.clip_slab(thickness=0.8, normal='z', origin=mesh.center),
-            mesh.clip_slab(thickness=0.8, normal='z', origin=mesh.center, invert=True),
+            mesh.clip_slab(thickness=0.8, normal='x', origin=center),
+            mesh.clip_slab(thickness=0.8, normal='x', origin=center, invert=True),
         ),
         'clip_surface': lambda: (
             mesh.clip_surface(surface, invert=True),
@@ -350,9 +359,37 @@ def test_clip_splits_the_mesh_in_two(mesh_type, name):
         ),
     }[name]()
 
-    measure = 'area' if isinstance(mesh, pv.PolyData) else 'volume'
-    whole = getattr(mesh, measure)
-    assert getattr(kept, measure) + getattr(removed, measure) == pytest.approx(whole, rel=1e-6)
+    # A split, not a pass-through, on both sides
+    assert kept.n_cells
+    assert removed.n_cells
+    if mesh_type == 'PolyData verts':
+        assert kept.n_cells + removed.n_cells == mesh.n_cells
+        return
+    if mesh_type == 'PolyData lines':
+
+        def measure(part):
+            return part.compute_cell_sizes(length=True)['Length'].sum()
+    else:
+        attr = 'area' if isinstance(mesh, pv.PolyData) else 'volume'
+
+        def measure(part):
+            return getattr(part, attr)
+
+    assert measure(mesh) > 0
+    assert measure(kept) + measure(removed) == pytest.approx(measure(mesh), rel=1e-6)
+
+
+def _seam_grid():
+    """Two grid halves that touch but share no points."""
+    grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
+    centers = grid.cell_centers().points[:, 2]
+    lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
+    upper = grid.extract_cells(np.flatnonzero(centers > 2)).cast_to_unstructured_grid()
+    lower.cell_data['half'] = np.zeros(lower.n_cells)
+    upper.cell_data['half'] = np.ones(upper.n_cells)
+    seam = lower.merge(upper, merge_points=False)
+    seam.point_data['scalars'] = np.linspace(0.0, 1.0, seam.n_points)
+    return seam
 
 
 @pytest.mark.parametrize(
@@ -418,19 +455,6 @@ def test_clip_box_keeps_a_face_lying_in_a_box_plane(make, invert):
     clipped = mesh.clip_box(box, invert=invert)
 
     assert clipped.n_cells == (0 if invert else mesh.n_cells)
-
-
-def _seam_grid():
-    """Two grid halves that touch but share no points."""
-    grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
-    centers = grid.cell_centers().points[:, 2]
-    lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
-    upper = grid.extract_cells(np.flatnonzero(centers > 2)).cast_to_unstructured_grid()
-    lower.cell_data['half'] = np.zeros(lower.n_cells)
-    upper.cell_data['half'] = np.ones(upper.n_cells)
-    seam = lower.merge(upper, merge_points=False)
-    seam.point_data['scalars'] = np.linspace(0.0, 1.0, seam.n_points)
-    return seam
 
 
 def test_clip_filter_normal(datasets):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -163,6 +163,7 @@ def _seam_polydata():
     mesh = pv.PolyData(points, np.array([3, 0, 1, 2, 3, 3, 4, 5]))
     mesh.cell_data['half'] = np.array([0.0, 1.0])
     mesh.point_data['height'] = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    mesh.point_data['scalars'] = mesh.point_data['height']
     return mesh
 
 
@@ -272,6 +273,155 @@ def test_clip_empty_output_keeps_array_names():
     assert sorted(clipped.array_names) == sorted(mesh.array_names)
     assert clipped.point_data['height'].dtype == np.float32
     assert clipped.cell_data['ids'].dtype == np.uint16
+
+
+def _cell_type_meshes():
+    """One mesh per input class and per cell type a clip has to preserve."""
+    axis = np.linspace(-1.0, 1.0, 4)
+    x, y, z = np.meshgrid(axis, axis, axis, indexing='ij')
+    explicit = pv.StructuredGrid(x, y, z)
+    explicit.dimensions = [4, 4, 4]
+    image = pv.ImageData(dimensions=(4, 4, 4), spacing=(0.6, 0.6, 0.6), origin=(-1, -1, -1))
+    meshes = {
+        'PolyData triangles': pv.Sphere(theta_resolution=8, phi_resolution=8),
+        'PolyData quads': pv.Plane(i_resolution=3, j_resolution=3),
+        'PolyData lines': pv.Line((-1, 0, 0), (1, 0, 0), resolution=4),
+        'PolyData verts': pv.PolyData(np.random.default_rng(0).uniform(-1, 1, (12, 3))),
+        'ImageData': image,
+        'RectilinearGrid': pv.RectilinearGrid(axis, axis, axis),
+        'StructuredGrid': pv.StructuredGrid(x, y, z),
+        'ExplicitStructuredGrid': explicit.cast_to_explicit_structured_grid(),
+        'UnstructuredGrid hexahedra': image.cast_to_unstructured_grid(),
+        'UnstructuredGrid tetrahedra': pv.Sphere(
+            theta_resolution=8, phi_resolution=8
+        ).delaunay_3d(),
+    }
+    for mesh in meshes.values():
+        mesh.point_data['scalars'] = np.linspace(0.0, 1.0, mesh.n_points)
+    return meshes
+
+
+def _cell_types(mesh):
+    """The cell types of a mesh, as an unstructured grid reports them."""
+    grid = mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
+    # A voxel is the same eight points as a hexahedron, ordered differently
+    return {
+        pv.CellType.HEXAHEDRON if t == pv.CellType.VOXEL else pv.CellType(t)
+        for t in grid.celltypes
+    }
+
+
+def _clip_that_removes_nothing(mesh, name):
+    """Apply one clip whose region contains the whole mesh."""
+    enclosing = pv.Cube(center=(0, 0, 0), x_length=99, y_length=99, z_length=99)
+    return {
+        'clip': lambda: mesh.clip(normal='z', origin=(0, 0, -99), invert=False),
+        'clip_box': lambda: mesh.clip_box([-99.0, 99.0] * 3, invert=False),
+        'clip_slab': lambda: mesh.clip_slab(thickness=999.0, normal='z'),
+        'clip_surface': lambda: mesh.clip_surface(enclosing),
+        'clip_scalar': lambda: mesh.clip_scalar(scalars='scalars', value=-99.0, invert=False),
+    }[name]()
+
+
+CLIP_FILTERS = ['clip', 'clip_box', 'clip_slab', 'clip_surface', 'clip_scalar']
+
+
+@pytest.mark.parametrize('name', CLIP_FILTERS)
+@pytest.mark.parametrize('mesh_type', list(_cell_type_meshes()))
+def test_clip_keeps_the_cell_types_it_does_not_cut(mesh_type, name):
+    """A clip that removes nothing leaves every cell as the type it was."""
+    mesh = _cell_type_meshes()[mesh_type]
+
+    clipped = _clip_that_removes_nothing(mesh, name)
+
+    assert clipped.n_cells == mesh.n_cells
+    assert _cell_types(clipped) == _cell_types(mesh)
+
+
+@pytest.mark.parametrize('name', CLIP_FILTERS)
+@pytest.mark.parametrize('mesh_type', list(_cell_type_meshes()))
+def test_clip_keeps_the_points_it_does_not_cut(mesh_type, name):
+    """A clip that removes nothing neither adds nor merges points."""
+    mesh = _cell_type_meshes()[mesh_type]
+
+    clipped = _clip_that_removes_nothing(mesh, name)
+
+    assert clipped.n_points == mesh.n_points
+    assert np.allclose(np.sort(clipped.points, axis=0), np.sort(mesh.points, axis=0))
+
+
+@pytest.mark.parametrize('name', CLIP_FILTERS)
+@pytest.mark.parametrize('mesh_type', list(_cell_type_meshes()))
+def test_clip_splits_the_mesh_in_two(mesh_type, name):
+    """What a clip keeps and what it removes add up to the whole mesh."""
+    mesh = _cell_type_meshes()[mesh_type]
+    surface = pv.Sphere(radius=0.7, center=mesh.center, theta_resolution=16, phi_resolution=16)
+    kept, removed = {
+        'clip': lambda: (
+            mesh.clip(normal='z', origin=mesh.center, invert=False),
+            mesh.clip(normal='z', origin=mesh.center, invert=True),
+        ),
+        'clip_box': lambda: (
+            mesh.clip_box([-0.4, 0.4] * 3, invert=False),
+            mesh.clip_box([-0.4, 0.4] * 3, invert=True),
+        ),
+        'clip_slab': lambda: (
+            mesh.clip_slab(thickness=0.8, normal='z', origin=mesh.center),
+            mesh.clip_slab(thickness=0.8, normal='z', origin=mesh.center, invert=True),
+        ),
+        'clip_surface': lambda: (
+            mesh.clip_surface(surface, invert=True),
+            mesh.clip_surface(surface, invert=False),
+        ),
+        'clip_scalar': lambda: (
+            mesh.clip_scalar(scalars='scalars', value=0.5, invert=True),
+            mesh.clip_scalar(scalars='scalars', value=0.5, invert=False),
+        ),
+    }[name]()
+
+    measure = 'area' if isinstance(mesh, pv.PolyData) else 'volume'
+    whole = getattr(mesh, measure)
+    assert getattr(kept, measure) + getattr(removed, measure) == pytest.approx(whole, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    'name', ['clip', 'clip_slab', 'clip_surface', 'clip_scalar', 'clip_box merge_points=False']
+)
+@pytest.mark.parametrize('mesh_type', ['PolyData', 'UnstructuredGrid'])
+def test_clip_keeps_coincident_points_apart_for_every_filter(mesh_type, name):
+    """No clip welds points the input held apart, except when asked to."""
+    mesh = _seam_polydata() if mesh_type == 'PolyData' else _seam_grid()
+    if name == 'clip_box merge_points=False':
+        clipped = mesh.clip_box([-99.0, 99.0] * 3, invert=False, merge_points=False)
+    else:
+        clipped = _clip_that_removes_nothing(mesh, name)
+
+    assert clipped.n_points == mesh.n_points
+    assert not _joins_the_halves(clipped)
+
+
+@pytest.mark.parametrize('mesh_type', ['PolyData', 'UnstructuredGrid'])
+def test_clip_box_merge_points_true_welds_every_input(mesh_type):
+    """``merge_points=True`` joins points that share a position."""
+    mesh = _seam_polydata() if mesh_type == 'PolyData' else _seam_grid()
+
+    merged = mesh.clip_box([-99.0, 99.0] * 3, invert=False, merge_points=True)
+
+    assert merged.n_points < mesh.n_points
+    assert _joins_the_halves(merged)
+
+
+def _seam_grid():
+    """Two grid halves that touch but share no points."""
+    grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
+    centers = grid.cell_centers().points[:, 2]
+    lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
+    upper = grid.extract_cells(np.flatnonzero(centers > 2)).cast_to_unstructured_grid()
+    lower.cell_data['half'] = np.zeros(lower.n_cells)
+    upper.cell_data['half'] = np.ones(upper.n_cells)
+    seam = lower.merge(upper, merge_points=False)
+    seam.point_data['scalars'] = np.linspace(0.0, 1.0, seam.n_points)
+    return seam
 
 
 def test_clip_filter_normal(datasets):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -177,6 +177,47 @@ def _joins_the_halves(mesh):
     return any(len(halves) > 1 for halves in halves_of_point.values())
 
 
+@pytest.mark.parametrize('both', [True, False])
+def test_clip_scalar_both_keeps_coincident_points_apart(both):
+    """Both halves of a scalar clip keep the points the input held apart."""
+    mesh = _seam_polydata()
+
+    result = mesh.clip_scalar(scalars='height', value=-99.0, invert=False, both=both)
+    kept = result[0] if both else result
+
+    assert type(kept) is pv.PolyData
+    assert kept.n_points == mesh.n_points
+    assert not _joins_the_halves(kept)
+
+
+def test_clip_strips_does_not_duplicate_points():
+    """A mesh mixing strips with other cells keeps one point per position."""
+    points = np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0], [1, 3, 0]], dtype=float)
+    mesh = pv.PolyData(points, faces=[3, 0, 1, 2], strips=[4, 0, 1, 3, 2])
+
+    clipped = mesh.clip(normal='x', origin=(1.0, 0.0, 0.0))
+
+    positions = {point.tobytes() for point in np.ascontiguousarray(clipped.points)}
+    assert clipped.n_points == len(positions)
+
+
+@pytest.mark.parametrize('name', ['clip', 'clip_slab'])
+def test_clip_composite_empty_block_keeps_array_names(name):
+    """An empty block says which arrays it would have had, as a lone dataset does."""
+    plane = pv.Plane()
+    plane.point_data['height'] = plane.points[:, 2]
+    composite = pv.MultiBlock({'plane': plane, 'empty': None})
+
+    clipped = {
+        'clip': lambda: composite.clip(normal='z', origin=(0, 0, 99), invert=False),
+        'clip_slab': lambda: composite.clip_slab(thickness=0.001, normal='z', origin=(0, 0, 99)),
+    }[name]()
+
+    assert clipped['plane'].is_empty
+    assert sorted(clipped['plane'].array_names) == sorted(plane.array_names)
+    assert clipped['empty'] is None
+
+
 @pytest.mark.parametrize(
     'name',
     ['clip', 'clip_slab', 'clip_surface', 'clip_scalar'],
@@ -222,12 +263,15 @@ def test_clip_box_merge_points_welds_when_asked(invert):
 def test_clip_empty_output_keeps_array_names():
     """An empty clip still says which arrays the input had."""
     mesh = pv.Plane()
-    mesh.point_data['height'] = mesh.points[:, 2]
+    mesh.point_data['height'] = mesh.points[:, 2].astype(np.float32)
+    mesh.cell_data['ids'] = np.arange(mesh.n_cells, dtype=np.uint16)
 
     clipped = mesh.clip(normal='z', origin=(0, 0, 99), invert=False)
 
     assert clipped.is_empty
     assert sorted(clipped.array_names) == sorted(mesh.array_names)
+    assert clipped.point_data['height'].dtype == np.float32
+    assert clipped.cell_data['ids'].dtype == np.uint16
 
 
 def test_clip_filter_normal(datasets):
@@ -434,7 +478,7 @@ def test_clip_box_polydata_no_unused_points(invert):
 
 @pytest.mark.parametrize('invert', [True, False])
 def test_clip_box_polydata_keeps_cells_and_arrays(invert):
-    """The output is the box filter's mesh in a PolyData, not a different mesh."""
+    """The clipped surface covers the same area and keeps its own cell types."""
     mesh = pv.Sphere(theta_resolution=16, phi_resolution=16)
     mesh.point_data['data'] = mesh.points[:, 2]
     mesh.cell_data['cells'] = np.arange(mesh.n_cells, dtype=float)
@@ -444,10 +488,10 @@ def test_clip_box_polydata_keeps_cells_and_arrays(invert):
     expected = _box_clip_filter(mesh, bounds, invert=invert).remove_unused_points()
 
     assert type(clipped) is pv.PolyData
-    assert clipped.n_cells == expected.n_cells
     assert clipped.area == pytest.approx(expected.area)
     assert sorted(clipped.array_names) == sorted(expected.array_names)
-    assert np.allclose(np.sort(clipped.points, axis=0), np.sort(expected.points, axis=0))
+    # The box planes keep the cells the box does not cut, which the box filter splits
+    assert set(clipped.cast_to_unstructured_grid().celltypes) != {pv.CellType.TRIANGLE}
 
 
 def test_clip_box_polydata_empty_is_polydata():

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -155,6 +155,81 @@ def test_clip_inplace_raises(mesh):
         mesh.clip(inplace=True)
 
 
+def _seam_polydata():
+    """Two triangles meeting along a diagonal, sharing coordinates but no points."""
+    points = np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=float
+    )
+    mesh = pv.PolyData(points, np.array([3, 0, 1, 2, 3, 3, 4, 5]))
+    mesh.cell_data['half'] = np.array([0.0, 1.0])
+    mesh.point_data['height'] = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    return mesh
+
+
+def _joins_the_halves(mesh):
+    """Whether any point is shared between cells of both halves."""
+    grid = mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
+    half = np.asarray(mesh.cell_data['half'])
+    halves_of_point = {}
+    for i in range(mesh.n_cells):
+        for point_id in grid.get_cell(i).point_ids:
+            halves_of_point.setdefault(point_id, set()).add(round(float(half[i])))
+    return any(len(halves) > 1 for halves in halves_of_point.values())
+
+
+@pytest.mark.parametrize(
+    'name',
+    ['clip', 'clip_slab', 'clip_surface', 'clip_scalar'],
+)
+def test_clip_keeps_coincident_points_apart(name):
+    """A clip that removes nothing must not weld points the input kept apart."""
+    mesh = _seam_polydata()
+    enclosing = pv.Cube(center=mesh.center, x_length=50, y_length=50, z_length=50)
+    clipped = {
+        'clip': lambda: mesh.clip(normal='z', origin=(0, 0, -99), invert=False),
+        'clip_slab': lambda: mesh.clip_slab(thickness=99.0, normal='z'),
+        'clip_surface': lambda: mesh.clip_surface(enclosing),
+        'clip_scalar': lambda: mesh.clip_scalar(scalars='height', value=-99.0, invert=False),
+    }[name]()
+
+    assert type(clipped) is pv.PolyData
+    assert clipped.n_points == mesh.n_points
+    assert not _joins_the_halves(clipped)
+
+
+@pytest.mark.parametrize('invert', [True, False])
+def test_clip_box_merge_points_welds_when_asked(invert):
+    """``merge_points`` decides whether coincident points are joined."""
+    grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()
+    centers = grid.cell_centers().points[:, 2]
+    lower = grid.extract_cells(np.flatnonzero(centers < 2)).cast_to_unstructured_grid()
+    upper = grid.extract_cells(np.flatnonzero(centers > 2)).cast_to_unstructured_grid()
+    lower.cell_data['half'] = np.zeros(lower.n_cells)
+    upper.cell_data['half'] = np.ones(upper.n_cells)
+    seam = lower.merge(upper, merge_points=False)
+    # A box that cuts in x only, so both halves survive either way
+    bounds = [3.0, 99.0, -99.0, 99.0, -99.0, 99.0]
+
+    merged = seam.clip_box(bounds, invert=invert, merge_points=True)
+    unmerged = seam.clip_box(bounds, invert=invert, merge_points=False)
+
+    assert _joins_the_halves(merged)
+    assert not _joins_the_halves(unmerged)
+    assert merged.n_points < unmerged.n_points
+    assert merged.volume == pytest.approx(unmerged.volume)
+
+
+def test_clip_empty_output_keeps_array_names():
+    """An empty clip still says which arrays the input had."""
+    mesh = pv.Plane()
+    mesh.point_data['height'] = mesh.points[:, 2]
+
+    clipped = mesh.clip(normal='z', origin=(0, 0, 99), invert=False)
+
+    assert clipped.is_empty
+    assert sorted(clipped.array_names) == sorted(mesh.array_names)
+
+
 def test_clip_filter_normal(datasets):
     # Test no errors are raised
     for i, dataset in enumerate(datasets):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -392,6 +392,34 @@ def test_clip_box_merge_points_true_welds_every_input(mesh_type):
     assert _joins_the_halves(merged)
 
 
+@pytest.mark.parametrize('invert', [True, False])
+@pytest.mark.parametrize(
+    'make',
+    [
+        pytest.param(lambda: (pv.Cube(), list(pv.Cube().bounds)), id='PolyData, six bounds'),
+        pytest.param(lambda: (pv.Cube(), pv.Cube()), id='PolyData, box mesh'),
+        pytest.param(
+            lambda: (pv.Cube().cast_to_unstructured_grid(), list(pv.Cube().bounds)),
+            id='UnstructuredGrid',
+        ),
+        pytest.param(
+            lambda: (
+                pv.Cube(center=(5e6, 0, 0), x_length=0.1, y_length=0.1, z_length=0.1),
+                list(pv.Cube(center=(5e6, 0, 0), x_length=0.1, y_length=0.1, z_length=0.1).bounds),
+            ),
+            id='PolyData far from the origin',
+        ),
+    ],
+)
+def test_clip_box_keeps_a_face_lying_in_a_box_plane(make, invert):
+    """A box that only touches a face keeps it, whichever way the box is given."""
+    mesh, box = make()
+
+    clipped = mesh.clip_box(box, invert=invert)
+
+    assert clipped.n_cells == (0 if invert else mesh.n_cells)
+
+
 def _seam_grid():
     """Two grid halves that touch but share no points."""
     grid = pv.ImageData(dimensions=(5, 5, 5)).cast_to_unstructured_grid()

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -178,26 +178,17 @@ def _joins_the_halves(mesh):
     return any(len(halves) > 1 for halves in halves_of_point.values())
 
 
-@pytest.mark.parametrize('both', [True, False])
-def test_clip_scalar_both_keeps_coincident_points_apart(both):
-    """Both halves of a scalar clip keep the points the input held apart."""
-    mesh = _seam_polydata()
-
-    result = mesh.clip_scalar(scalars='height', value=-99.0, invert=False, both=both)
-    kept = result[0] if both else result
-
-    assert type(kept) is pv.PolyData
-    assert kept.n_points == mesh.n_points
-    assert not _joins_the_halves(kept)
-
-
-def test_clip_strips_does_not_duplicate_points():
-    """A mesh mixing strips with other cells keeps one point per position."""
+@pytest.mark.parametrize('name', ['clip', 'clip_box', 'clip_slab', 'clip_surface', 'clip_scalar'])
+def test_clip_strips_does_not_duplicate_points(name):
+    """A mesh mixing strips with other cells keeps one point per position, quietly."""
     points = np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0], [1, 3, 0]], dtype=float)
     mesh = pv.PolyData(points, faces=[3, 0, 1, 2], strips=[4, 0, 1, 3, 2])
+    mesh.point_data['scalars'] = np.linspace(0.0, 1.0, mesh.n_points)
 
-    clipped = mesh.clip(normal='x', origin=(1.0, 0.0, 0.0))
+    with pv.VtkErrorCatcher() as catcher:
+        clipped = _clip_that_removes_nothing(mesh, name)
 
+    assert not catcher.events
     positions = {point.tobytes() for point in np.ascontiguousarray(clipped.points)}
     assert clipped.n_points == len(positions)
 
@@ -217,26 +208,6 @@ def test_clip_composite_empty_block_keeps_array_names(name):
     assert clipped['plane'].is_empty
     assert sorted(clipped['plane'].array_names) == sorted(plane.array_names)
     assert clipped['empty'] is None
-
-
-@pytest.mark.parametrize(
-    'name',
-    ['clip', 'clip_slab', 'clip_surface', 'clip_scalar'],
-)
-def test_clip_keeps_coincident_points_apart(name):
-    """A clip that removes nothing must not weld points the input kept apart."""
-    mesh = _seam_polydata()
-    enclosing = pv.Cube(center=mesh.center, x_length=50, y_length=50, z_length=50)
-    clipped = {
-        'clip': lambda: mesh.clip(normal='z', origin=(0, 0, -99), invert=False),
-        'clip_slab': lambda: mesh.clip_slab(thickness=99.0, normal='z'),
-        'clip_surface': lambda: mesh.clip_surface(enclosing),
-        'clip_scalar': lambda: mesh.clip_scalar(scalars='height', value=-99.0, invert=False),
-    }[name]()
-
-    assert type(clipped) is pv.PolyData
-    assert clipped.n_points == mesh.n_points
-    assert not _joins_the_halves(clipped)
 
 
 @pytest.mark.parametrize('invert', [True, False])
@@ -385,7 +356,15 @@ def test_clip_splits_the_mesh_in_two(mesh_type, name):
 
 
 @pytest.mark.parametrize(
-    'name', ['clip', 'clip_slab', 'clip_surface', 'clip_scalar', 'clip_box merge_points=False']
+    'name',
+    [
+        'clip',
+        'clip_slab',
+        'clip_surface',
+        'clip_scalar',
+        'clip_scalar both=True',
+        'clip_box merge_points=False',
+    ],
 )
 @pytest.mark.parametrize('mesh_type', ['PolyData', 'UnstructuredGrid'])
 def test_clip_keeps_coincident_points_apart_for_every_filter(mesh_type, name):
@@ -393,6 +372,8 @@ def test_clip_keeps_coincident_points_apart_for_every_filter(mesh_type, name):
     mesh = _seam_polydata() if mesh_type == 'PolyData' else _seam_grid()
     if name == 'clip_box merge_points=False':
         clipped = mesh.clip_box([-99.0, 99.0] * 3, invert=False, merge_points=False)
+    elif name == 'clip_scalar both=True':
+        clipped = mesh.clip_scalar(scalars='scalars', value=-99.0, invert=False, both=True)[0]
     else:
         clipped = _clip_that_removes_nothing(mesh, name)
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -260,7 +260,7 @@ def _cell_type_meshes():
             np.array([[x, 0.0, 0.0] for x in np.linspace(-1.0, 1.0, 5)]),
             lines=[2, 0, 1, 2, 1, 2, 2, 2, 3, 2, 3, 4],
         ),
-        'PolyData verts': pv.PolyData(np.random.default_rng(0).uniform(-1, 1, (12, 3))),
+        'PolyData verts': pv.PolyData(np.random.default_rng(0).uniform(-0.6, 0.6, (60, 3))),
         'ImageData': image,
         'RectilinearGrid': pv.RectilinearGrid(axis, axis, axis),
         'StructuredGrid': pv.StructuredGrid(x, y, z),

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -395,12 +395,8 @@ def test_clip_scalar_multiple():
     mesh_clip_y = mesh.clip_scalar(scalars='y', value=0.0)
     assert np.isclose(mesh_clip_y['y'].max(), 0.0)
     mesh_clip_z = mesh.clip_scalar(scalars='z', value=0.0)
-    if pv.vtk_version_info >= (9, 7):
-        # Behavior change with vtkClipPolyData where the isovalue itself is no longer included
-        # in the inside-out mesh https://gitlab.kitware.com/vtk/vtk/-/work_items/20017
-        assert mesh_clip_z['z'].size == 0
-    else:
-        assert np.isclose(mesh_clip_z['z'].max(), 0.0)
+    # A scalar at the value itself is not below it
+    assert mesh_clip_z['z'].size == 0
 
 
 def test_clip_surface():


### PR DESCRIPTION
Follow-up to the clip and slice performance work in #9073 and #9074 and to #9130, which made the output type of every clip and slice filter follow from its input class. This does the same for `merge_points`: it currently does nothing in either direction for the five grid classes, and four of the five clip filters destroy a `PolyData`'s coincident points with no way to keep them. Now it means one thing for every input class — merge points that share a position, or leave them apart — and no clip welds what the input kept apart.

Measured on a two-triangle surface that shares coordinates but no points, clipped so that nothing is removed. Only the representation can differ:

| input \| filter | 0.48.4 | before the perf work | `main` | here |
| --- | --- | --- | --- | --- |
| `PolyData` \| `clip`, `clip_slab`, `clip_surface`, `clip_scalar` | welded | welded | welded | **kept** |
| `PolyData` \| `clip_box merge_points=True` | welded | welded | welded | welded |
| `PolyData` \| `clip_box merge_points=False` | kept | kept | kept | kept |
| grid \| `clip`, `clip_slab`, `clip_surface`, `clip_scalar` | kept | kept | kept | kept |
| grid \| `clip_box merge_points=True` | welded | welded | **kept** | **welded** |
| grid \| `clip_box merge_points=False` | kept | kept | **kept** | kept |

`vtkClipPolyData` was the only clipper that welded; every other input class already used `vtkTableBasedClipDataSet`, which keeps coincident points and is faster. One helper now picks the clipper for all five filters, and `merge_points` is a single explicit merge pass after the clip rather than a choice of locator, so it applies to every input class.

| | `main` | here | |
| --- | --- | --- | --- |
| `PolyData.clip`, 90k cells | 14.3 ms | **2.5 ms** | 5.6x faster |
| grid `clip_box`, 216k cells | 29.5 ms | 31.5 ms | the merge pass |
| grid `clip` | 5.5 ms | 5.4 ms | |

Area and volume are unchanged everywhere. A clipped surface gains about 0.8% more points, where the clip surface passes exactly through a point several cells share.

`clip_box` also stops using `vtkBoxClipDataSet`, so it no longer splits a surface into triangles: `pv.Cube().clip_box(...)` keeps its quads. It clips by the six planes from the inside, which keeps a face lying in a box plane, with no epsilon, at any coordinate, whether the box is six bounds or a mesh.

| | `main` | here | |
| --- | --- | --- | --- |
| `PolyData.clip_box`, 90k cells | 97.2 ms | **2.5 ms** | 39x faster |

Two inputs keep the old clipper: a `PolyData` carrying triangle strips, which `vtkTableBasedClipDataSet` does not support and would emit twice, and the `add_mesh_clip_box` widget. An explicit structured grid is clipped as an unstructured grid below VTK 9.5, where the table-based clipper would hand it to one that tetrahedralizes. One visible consequence of leaving `vtkClipPolyData`: an inside-out `clip_scalar` of a `PolyData` drops cells sitting exactly at the value on every VTK version, as it already did on 9.7. The five clip docstrings carry a `versionchanged` for the merging.

A matrix over ten inputs and five filters holds the claims above: a clip that removes nothing keeps every cell type and every point, what a clip keeps and what it removes add up to the whole mesh, no clip welds points the input held apart unless `merge_points` asks, strips stay quiet, and a box that only touches a face keeps it. Reverting the filters fails eighteen of them.

Changes drafted by Claude Opus 5 and Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5, Claude Fable 5.1)
