### PR TITLE
Kill hung tests with pytest-timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ test = [
   'pytest-cov<7.2.0',
   'pytest-mock<3.16.0',
   'pytest-pyvista==0.3.3',
+  'pytest-timeout<2.5.0',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
   'pyvista-frd-reader>=0.2.1,<0.3.0',

--- a/tox.ini
+++ b/tox.ini
@@ -47,11 +47,11 @@ passenv =
 
 setenv =
     TOX_ROOT = {tox_root}
-    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
+    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --timeout=300 --timeout-method=thread
     # Opting out of the reference leak check (see tests/gc_check.py) goes here rather
     # than in the commands below because those pass their arguments as posargs defaults,
     # which a scoped run replaces wholesale.
-    no_check_gc: PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --no_check_gc
+    no_check_gc: PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --timeout=300 --timeout-method=thread --no_check_gc
     cov: COVERAGE_CORE = {env:COVERAGE_CORE:ctrace}
 
 dependency_groups = test
@@ -181,8 +181,6 @@ basepython =
     cvista: {env:CVISTA_PYTHON:py3.13}
     nightly: py3.14
 dependency_groups = test
-# Not in the `test` group; guards against a single stuck test burning the job budget.
-deps = pytest-timeout
 setenv =
     # A named env's setenv replaces [testenv]'s, so repeat TOX_ROOT (tests read
     # pyproject.toml through it).


### PR DESCRIPTION
Windows unit-test wall time is bimodal: 12-15 min normally, but 44-48 min in 5 of the 194 successful runs on `main` between 23 Aug and 6 Sep. The slow runs are not slow machines. A test hangs, the plotting step's `nick-fields/retry` wrapper kills the whole `tox run` at its 30-minute limit, and the rerun passes, so the job still shows green. [This job](https://github.com/pyvista/pyvista/actions/runs/34063952580/job/101569344782) shows it: one xdist worker stops reporting right after a `tests/plotting/test_cli.py::test_plot` case that spawns a child process, the other worker finishes the rest of the suite alone, and the session then sits at 90% waiting for the stuck worker's queue until the wrapper logs `Attempt 1 failed. Reason: Timeout of 1800000ms hit` and starts over. Four of the five hung runs stall in those `test_cli` child-process cases; the fifth stalls in a `test_tinypages` sphinx-build child.

This adds `pytest-timeout` to the `test` group and `--timeout=300 --timeout-method=thread` to the shared tox test-env options (the integration env already had a private copy of the same dependency, now folded in). A hung test now fails after 5 minutes with the test named in the report, the stuck xdist worker is replaced and its remaining tests rescheduled, and the retry wrapper stays as a last resort. The slowest legitimate test on the Windows runner takes about a minute, so 300 s leaves a wide margin.

| Windows unit job | Plotting step | Total |
| --- | --- | --- |
| Normal | 6-7 min | 12-15 min |
| Hung attempt + rerun (5 of 194 runs) | 35-39 min | 44-48 min |

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
