### PR TITLE
Bump `setup-headless-display-action` to v5.1.0 to stop Windows exit hangs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
         run: echo "retry_test_timeout=$(( TIMEOUT / 2 ))" | tee -a "$GITHUB_OUTPUT"
         id: set_timeout
 
-      - uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
+      - uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
         with:
           qt: ${{matrix.project == 'pyvistaqt' || matrix.project == 'mne'}}
           pyvista: ${{matrix.project != 'pyvistaqt' && matrix.project != 'mne' && matrix.project != 'geovista'}}

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Setup headless display on Windows
         if: runner.os == 'Windows'
-        uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
 
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         if: runner.os == 'Linux'

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -58,6 +58,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
+      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
+      - name: Disable llvmpipe threads
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
+
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -58,12 +58,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
-      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
-      - name: Disable llvmpipe threads
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
-
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -336,6 +336,12 @@ jobs:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
+      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
+      - name: Disable llvmpipe threads
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
+
       - name: Install tox-uv
         run: pip install tox-uv
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -336,12 +336,6 @@ jobs:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
-      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
-      - name: Disable llvmpipe threads
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
-
       - name: Install tox-uv
         run: pip install tox-uv
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -334,7 +334,7 @@ jobs:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
 
       - name: Install tox-uv
         run: pip install tox-uv

--- a/.github/workflows/validate-makefile.yml
+++ b/.github/workflows/validate-makefile.yml
@@ -47,7 +47,7 @@ jobs:
       # OpenGL backends. Without a headless display those imports segfault,
       # so set one up before the tox envs run.
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
 
       # `make sync-deps` is not a "dry-run" — we need the dev group installed
       # so the subsequent `uv run` invocations resolve without re-bootstrapping.

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -486,7 +486,7 @@ jobs:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
 
       - name: Install tox-uv
         run: pip install tox-uv

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -488,6 +488,12 @@ jobs:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
+      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
+      - name: Disable llvmpipe threads
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
+
       - name: Install tox-uv
         run: pip install tox-uv
 

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -488,12 +488,6 @@ jobs:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e
 
-      # llvmpipe's rasterizer teardown deadlocks at process exit on Windows.
-      - name: Disable llvmpipe threads
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "LP_NUM_THREADS=0" >> "$GITHUB_ENV"
-
       - name: Install tox-uv
         run: pip install tox-uv
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ passenv =
     *SSL*
     COVERAGE*
     CI*
+    LP_*
     MESA*
     VTK*
     DISPLAY*


### PR DESCRIPTION
### Overview

The Windows unit-test job hangs a few percent of the time inside a test that spawns a child process which renders and then exits. #9161 turned that from a silent 30-minute stall into a 5-minute failure ([example](https://github.com/pyvista/pyvista/actions/runs/34278577433/job/102492348493)), but the hang itself remained. Stress-running the CLI child on windows-latest in [user27182/pyvista#3](https://github.com/user27182/pyvista/pull/3) reproduces it in about 1% of spawns, and a cdb stack of the stuck process shows it inside `osmesa.dll`'s DLL detach handler under `LdrShutdownProcess`, waiting on a condition variable. That is OSMesa's `atexit` handler destroying its global llvmpipe screen: `lp_rast_destroy` waits on each rasterizer thread's `exited` semaphore when the thread still reports as running, but `ExitProcess` has already killed those threads, so the wait never returns and the process cannot even be terminated from outside. The interpreter had fully shut down in every capture, and closing every plotter before exit made no difference, so nothing in PyVista can prevent it.

`LP_NUM_THREADS=0` removes the rasterizer threads and with them the hang, while disabling the shader cache, the other thread pool torn down on that path, does not. Per-spawn render time was unchanged or slightly faster, since the test images are small.

| windows-latest, 3 jobs of 1000 `pyvista plot --off-screen --screenshot` spawns each | hangs |
| --- | --- |
| baseline | 37 / 3000 |
| `MESA_SHADER_CACHE_DISABLE=true` | 15 / 2000 |
| `LP_NUM_THREADS=0` | 0 / 3000 |

pyvista/setup-headless-display-action#55 made the action export `LP_NUM_THREADS=0` next to `VTK_DEFAULT_OPENGL_WINDOW`, released as v5.1.0. This bumps every use of the action to that release and adds `LP_*` to tox's `passenv`, without which the variable would stop at the tox boundary and never reach pytest or the children it spawns.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
