### PR TITLE
Restore Plotter.image for subclasses that override the render window check

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2408,7 +2408,7 @@ class BasePlotter(_BoundsSizeMixin):
                 'Consider setting ``off_screen=True`` '
                 'for off screen rendering.\n'
             )
-            raise AttributeError(msg)
+            raise RuntimeError(msg)
 
     def _check_has_ren_win(self) -> None:
         """Check if render window attribute exists and raise an exception if not."""
@@ -2444,6 +2444,10 @@ class BasePlotter(_BoundsSizeMixin):
     @property
     def image(self) -> NumpyArray[np.uint8]:  # numpydoc ignore=RT01
         """Return an image array of current render window.
+
+        .. versionchanged:: 0.50
+            A :class:`RuntimeError` is raised instead of an
+            :class:`AttributeError` when the plotter has not been rendered.
 
         Returns
         -------
@@ -6150,6 +6154,10 @@ class BasePlotter(_BoundsSizeMixin):
         reset_camera_clipping_range: bool = True,  # noqa: FBT001, FBT002
     ) -> NumpyArray[np.float32]:
         """Return a depth image representing current render window.
+
+        .. versionchanged:: 0.50
+            A :class:`RuntimeError` is raised instead of an
+            :class:`AttributeError` when the plotter has not been rendered.
 
         .. versionchanged:: 0.47
             The last image depth is no longer automatically stored. You must

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2410,15 +2410,14 @@ class BasePlotter(_BoundsSizeMixin):
             )
             raise AttributeError(msg)
 
-    def _check_has_ren_win(self) -> _vtk.vtkRenderWindow:
-        """Return the render window, raising if there is none or it is not current."""
+    def _check_has_ren_win(self) -> None:
+        """Check if render window attribute exists and raise an exception if not."""
         if self.render_window is None:
             msg = 'Render window is not available.'
             raise RenderWindowUnavailable(msg)
         if not self.render_window.IsCurrent():
             msg = 'Render window is not current.'
             raise RenderWindowUnavailable(msg)
-        return self.render_window
 
     def _make_render_window_current(self) -> None:
         if self.render_window is None:
@@ -2464,7 +2463,8 @@ class BasePlotter(_BoundsSizeMixin):
             return self.last_image
 
         self._check_rendered()
-        render_window = self._check_has_ren_win()
+        self._check_has_ren_win()
+        render_window = cast('_vtk.vtkRenderWindow', self.render_window)
 
         return image_from_window(
             render_window,
@@ -6200,7 +6200,8 @@ class BasePlotter(_BoundsSizeMixin):
                 '`store_image_depth=True` when using `get_image_depth`.'
             )
             raise RuntimeError(msg)
-        render_window = self._check_has_ren_win()
+        self._check_has_ren_win()
+        render_window = cast('_vtk.vtkRenderWindow', self.render_window)
 
         # Ensure points in view are within clipping range of renderer?
         if reset_camera_clipping_range:

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -55,6 +55,8 @@ def test_plotter_image_before_show_subclass_getattr():
             raise AttributeError(msg)
 
     pl = _SubPlotter()
+    with pytest.raises(AttributeError, match='has no attribute'):
+        _ = pl.not_an_attribute
     with pytest.raises(RuntimeError, match='not yet been set up'):
         _ = pl.image
     with pytest.raises(RuntimeError, match='not yet been set up'):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -51,6 +51,24 @@ def test_has_render_window_fail():
         pl._make_render_window_current()
 
 
+def test_image_with_overridden_check_has_ren_win(sphere):
+    """A subclass may override the check, so its return value must not be used."""
+
+    class _SubPlotter(pv.Plotter):
+        """Plotter whose render window check returns ``None``."""
+
+        def _check_has_ren_win(self) -> None:
+            """Check the render window with the base class implementation."""
+            pv.Plotter._check_has_ren_win(self)
+
+    pl = _SubPlotter()
+    pl.add_mesh(sphere)
+    pl.show(auto_close=False)
+    assert pl.image.ndim == 3
+    assert pl.image_depth.ndim == 2
+    pl.close()
+
+
 def test_render_lines_as_tubes_show_edges_warning(sphere):
     pl = pv.Plotter()
     with pytest.warns(UserWarning, match='not supported'):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -38,8 +38,27 @@ if TYPE_CHECKING:
 @pytest.mark.skip_egl('OSMesa/EGL builds will not fail.')
 def test_plotter_image_before_show():
     pl = pv.Plotter()
-    with pytest.raises(AttributeError, match='not yet been set up'):
+    with pytest.raises(RuntimeError, match='not yet been set up'):
         _ = pl.image
+
+
+@pytest.mark.skip_egl('OSMesa/EGL builds will not fail.')
+def test_plotter_image_before_show_subclass_getattr():
+    """A subclass ``__getattr__`` must not mask what the property raises."""
+
+    class _SubPlotter(pv.Plotter):
+        """Plotter that reports every unresolved attribute as missing."""
+
+        def __getattr__(self, name):
+            """Raise for an attribute found neither on the instance nor the class."""
+            msg = f'{type(self).__name__} has no attribute {name!r}'
+            raise AttributeError(msg)
+
+    pl = _SubPlotter()
+    with pytest.raises(RuntimeError, match='not yet been set up'):
+        _ = pl.image
+    with pytest.raises(RuntimeError, match='not yet been set up'):
+        _ = pl.image_depth
 
 
 def test_has_render_window_fail():


### PR DESCRIPTION
`BasePlotter._check_has_ren_win` began returning the render window in #9125, but subclasses override it and return nothing, so `image` and `get_image_depth` passed `None` to `image_from_window`. Both now read `render_window` from the plotter, as they did before.

That `AttributeError` reached users as `BackgroundPlotter has no attribute 'image'`: an `AttributeError` raised inside a property is swallowed by a subclass `__getattr__`, which reports the property itself as missing. `_check_rendered` now raises `RuntimeError` instead, so the real message survives.

- pyvistaqt's `QtInteractor` and MNE's `_SafeBackgroundPlotter` both override the check and both inherit that `__getattr__`; all 19 `mne` failures and all 12 `pyvistaqt` failures in the last Integration Tests run share it.
- With this change the pyvistaqt integration suite passes locally apart from a macOS-only `devicePixelRatio` assertion in `test_screenshot_unrealized`.

Resolves #9173

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
