### PR TITLE
Fix `generic_filter` replacing every block error with `RuntimeError`

### DIFF
--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -79,10 +79,14 @@ class CompositeFilters(DataObjectFilters):
 
         Raises
         ------
-        RuntimeError
-            Raised if the filter cannot be applied to any block for any reason. This
-            overrides ``TypeError``, ``ValueError``, ``AttributeError`` errors when
-            filtering.
+        Exception
+            The error a block raises is re-raised as is, with the index, name and
+            type of that block added to its message.
+
+            .. versionchanged:: 0.50
+
+                The error keeps its own class. Previously every error was replaced by
+                a ``RuntimeError``.
 
         See Also
         --------
@@ -148,8 +152,9 @@ class CompositeFilters(DataObjectFilters):
         :class:`~pyvista.ImageData`.
 
         >>> multi.generic_filter('resample', 0.5)  # doctest:+SKIP
-        RuntimeError: The filter 'resample' could not be applied to the block at index 1 with
-        name 'Block-01' and type PolyData.
+        AttributeError: The filter 'resample'
+        could not be applied to the block at index 1 with name 'Block-01' and type PolyData:
+        'PolyData' object has no attribute 'resample'
 
         Use a custom function instead to apply the generic filter conditionally. Here we
         filter the image blocks but simply pass-through a copy of any other blocks.
@@ -182,8 +187,8 @@ class CompositeFilters(DataObjectFilters):
                     else functools.partial(function_, block_)
                 )
                 output_ = function_(**kwargs) if len(args) == 0 else function_(*args, **kwargs)
-            except (AttributeError, ValueError, TypeError, RuntimeError) as e:
-                # Construct a helpful error message
+            except Exception as e:
+                # Name the block in the error, keeping the error's own class
                 func_name = (
                     function_.func if isinstance(function_, functools.partial) else function_
                 )
@@ -197,9 +202,10 @@ class CompositeFilters(DataObjectFilters):
                 msg = (
                     f"The filter '{func_name}'\n"
                     f'could not be applied to the{nested}block at index {index} with '
-                    f"name '{name_}' and type {obj_name}."
+                    f"name '{name_}' and type {obj_name}"
                 )
-                raise RuntimeError(msg) from e
+                e.args = (f'{msg}:\n{e}' if str(e) else f'{msg}.', *e.args[1:])
+                raise
             return output_
 
         def get_iterator(multi, skip_none_, skip_empty_):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1484,9 +1484,9 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
     match = (
         "The filter 'resample'\ncould not be applied to the block at index 1 with name "
-        "'Block-01' and type RectilinearGrid."
+        "'Block-01' and type RectilinearGrid:\n'RectilinearGrid' object has no attribute"
     )
-    with pytest.raises(RuntimeError, match=match):
+    with pytest.raises(AttributeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
@@ -1494,22 +1494,49 @@ def test_generic_filter_raises(multiblock_all_with_nested_and_none):
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
     match = (
         "The filter 'resample'\ncould not be applied to the nested block at index [0][1] "
-        "with name 'Block-01' and type RectilinearGrid."
+        "with name 'Block-01' and type RectilinearGrid:"
     )
-    with pytest.raises(RuntimeError, match=re.escape(match)):
+    with pytest.raises(AttributeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
         )
     # Test with invalid kwargs
     match = "The filter '<bound method DataSetFilters.align_xyz of ImageData"
-    with pytest.raises(RuntimeError, match=re.escape(match)):
+    with pytest.raises(TypeError, match=re.escape(match)):
         multiblock_all_with_nested_and_none.generic_filter('align_xyz', foo='bar')
+
     # Test with function
-    match = "The filter '<function test_generic_filter_raises"
-    with pytest.raises(RuntimeError, match=match):
-        multiblock_all_with_nested_and_none.generic_filter(
-            test_generic_filter_raises,
-        )
+    def fail(block):
+        msg = f'cannot filter {type(block).__name__}'
+        raise ValueError(msg)
+
+    match = "The filter '<function test_generic_filter_raises.<locals>.fail"
+    with pytest.raises(ValueError, match=match):
+        multiblock_all_with_nested_and_none.generic_filter(fail)
+
+
+def test_generic_filter_keeps_error_class(multiblock_all_with_nested_and_none):
+    class BlockError(Exception):
+        pass
+
+    def fail(block):
+        msg = f'cannot filter {type(block).__name__}'
+        raise BlockError(msg)
+
+    match = (
+        "could not be applied to the block at index 0 with name 'Block-00' and type "
+        'ImageData:\ncannot filter ImageData'
+    )
+    with pytest.raises(BlockError, match=match) as info:
+        multiblock_all_with_nested_and_none.generic_filter(fail)
+    assert info.value.__cause__ is None
+
+    # An error without a message gets the block, and nothing else
+    def fail_silently(_):
+        raise BlockError
+
+    with pytest.raises(BlockError, match=r'type ImageData\.$'):
+        multiblock_all_with_nested_and_none.generic_filter(fail_silently)
 
 
 def test_block_types(multiblock_all_with_nested_and_none):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1843,7 +1843,7 @@ def test_cell_quality_composite(
     multiblock_all_with_nested_and_none, multiblock_all_no_pointset_with_nested_and_none
 ):
     match = "could not be applied to the block at index 5 with name 'Block-05' and type PointSet"
-    with pytest.raises(RuntimeError, match=match):
+    with pytest.raises(pv.PointSetCellOperationError, match=match):
         qual = multiblock_all_with_nested_and_none.cell_quality([SHAPE])
 
     qual = multiblock_all_no_pointset_with_nested_and_none.cell_quality([SHAPE])
@@ -4077,15 +4077,10 @@ def test_extract_surface_nonlinear(as_multiblock):
     with pytest.raises(ValueError, match=match):
         grid.extract_surface(algorithm='geometry', nonlinear_subdivision=5)
 
+    match = 'Mesh contains non-linear cells which cannot be processed by the geometry algorithm.'
     if as_multiblock:
-        expected_error = RuntimeError
-        match = 'could not be applied to the block at index 0'
-    else:
-        expected_error = ValueError
-        match = (
-            'Mesh contains non-linear cells which cannot be processed by the geometry algorithm.'
-        )
-    with pytest.raises(expected_error, match=match):
+        match = '(?s)could not be applied to the block at index 0.*' + match
+    with pytest.raises(ValueError, match=match):
         grid.extract_surface(algorithm='geometry')
 
     # No subdivision, expect one face per cell


### PR DESCRIPTION
### Overview

Every error a block raised inside `generic_filter` came back as a bare `RuntimeError`, so a caller could not catch the real class, say a `PointSetCellOperationError` from `cell_quality` on a composite, and the message named the block while the actual cause sat behind `__cause__`. The error now keeps its own class with the block's index, name and type prepended to its message, and the `except` no longer needs to be selective. Breaking for anyone catching `RuntimeError` around a composite filter.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
