### PR TITLE
Filter a composite block by block instead of handing it to VTK

### DIFF
--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -79,10 +79,14 @@ class CompositeFilters(DataObjectFilters):
 
         Raises
         ------
-        RuntimeError
-            Raised if the filter cannot be applied to any block for any reason. This
-            overrides ``TypeError``, ``ValueError``, ``AttributeError`` errors when
-            filtering.
+        Exception
+            The error a block raises is re-raised as is, with the index, name and
+            type of that block added to its message.
+
+            .. versionchanged:: 0.50
+
+                The error keeps its own class. Previously every error was replaced by
+                a ``RuntimeError``.
 
         See Also
         --------
@@ -148,8 +152,9 @@ class CompositeFilters(DataObjectFilters):
         :class:`~pyvista.ImageData`.
 
         >>> multi.generic_filter('resample', 0.5)  # doctest:+SKIP
-        RuntimeError: The filter 'resample' could not be applied to the block at index 1 with
-        name 'Block-01' and type PolyData.
+        AttributeError: The filter 'resample'
+        could not be applied to the block at index 1 with name 'Block-01' and type PolyData:
+        'PolyData' object has no attribute 'resample'
 
         Use a custom function instead to apply the generic filter conditionally. Here we
         filter the image blocks but simply pass-through a copy of any other blocks.
@@ -182,8 +187,8 @@ class CompositeFilters(DataObjectFilters):
                     else functools.partial(function_, block_)
                 )
                 output_ = function_(**kwargs) if len(args) == 0 else function_(*args, **kwargs)
-            except (AttributeError, ValueError, TypeError, RuntimeError) as e:
-                # Construct a helpful error message
+            except Exception as e:
+                # Name the block in the error, keeping the error's own class
                 func_name = (
                     function_.func if isinstance(function_, functools.partial) else function_
                 )
@@ -197,9 +202,10 @@ class CompositeFilters(DataObjectFilters):
                 msg = (
                     f"The filter '{func_name}'\n"
                     f'could not be applied to the{nested}block at index {index} with '
-                    f"name '{name_}' and type {obj_name}."
+                    f"name '{name_}' and type {obj_name}"
                 )
-                raise RuntimeError(msg) from e
+                e.args = (f'{msg}:\n{e}' if str(e) else f'{msg}.', *e.args[1:])
+                raise
             return output_
 
         def get_iterator(multi, skip_none_, skip_empty_):

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1837,6 +1837,15 @@ class DataObjectFilters:
             msg = 'Planarity tolerance requires VTK 9.6 or later.'
             raise pv.VTKVersionError(msg)
 
+        # Validate block by block so each block takes the path for its own type
+        if isinstance(self, pv.MultiBlock):
+            return self.generic_filter(
+                'cell_validator',
+                tolerance=tolerance,
+                planarity_tolerance=planarity_tolerance,
+                size_tolerance=size_tolerance,
+            )
+
         # A cell referencing a point id which does not exist makes VTK read out of bounds,
         # so skip the checks which dereference cell points when the connectivity is invalid
         invalid_references = _has_invalid_point_references(self)
@@ -1963,10 +1972,7 @@ class DataObjectFilters:
             state[is_invalid] |= CellStatus.INVALID_POINT_REFERENCES
             return
 
-        if isinstance(output, pv.DataSet):
-            post_process(output)
-        else:
-            output.generic_filter(post_process)
+        post_process(output)
         return output
 
     @_deprecate_positional_args(allowed=['trans'])
@@ -4466,7 +4472,12 @@ class DataObjectFilters:
                 PyVistaDeprecationWarning,
             )
 
-        _raise_if_composite_has_pointset(self, error=pv.core.errors.PointSetCellOperationError)
+        # Extract block by block so each block takes the path for its own type
+        if isinstance(self, pv.MultiBlock):
+            return self.generic_filter(
+                'extract_all_edges', clear_data=clear_data, progress_bar=progress_bar
+            )
+
         alg = _vtk.vtkExtractEdges()
         alg.SetInputDataObject(self)
         # Always use all points since VTK >= 9.2 is required
@@ -4984,15 +4995,24 @@ class DataObjectFilters:
             if volume:
                 dataset.cell_data['Volume'] = np.empty(shape=(0,))
 
+        # Compute block by block so each block takes the path for its own type
+        if isinstance(self, pv.MultiBlock):
+            return self.generic_filter(
+                'compute_cell_sizes',
+                length=length,
+                area=area,
+                volume=volume,
+                progress_bar=progress_bar,
+                vertex_count=vertex_count,
+            )
+
         if self.is_empty:
             # Ensure outputs have arrays so things like `mesh.area` and `mesh.volume` still work
             # Also guard against seg fault https://gitlab.kitware.com/vtk/vtk/-/issues/19978
             out = self.copy()
-            if not isinstance(out, pv.MultiBlock):
-                ensure_arrays_if_empty(out)
+            ensure_arrays_if_empty(out)
             return out
 
-        _raise_if_composite_has_pointset(self, error=pv.core.errors.PointSetCellOperationError)
         alg = _vtk.vtkCellSizeFilter()
         alg.SetInputDataObject(self)
         alg.SetComputeArea(area)
@@ -5114,17 +5134,19 @@ class DataObjectFilters:
         >>> surf.plot(scalars='Area')
 
         """
-        _raise_if_composite_has_pointset(self)
+        # Convert block by block so each block takes the path for its own type
+        if isinstance(self, pv.MultiBlock):
+            return self.generic_filter(
+                'cell_data_to_point_data', pass_cell_data=pass_cell_data, progress_bar=progress_bar
+            )
+
         alg = _vtk.vtkCellDataToPointData()
         alg.SetInputDataObject(self)
         alg.SetPassCellData(pass_cell_data)
         _update_alg(
             alg, progress_bar=progress_bar, message='Transforming cell data into point data.'
         )
-        active_scalars = None
-        if not isinstance(self, pv.MultiBlock):
-            active_scalars = self.active_scalars_name
-        return _get_output(alg, active_scalars=active_scalars)
+        return _get_output(alg, active_scalars=self.active_scalars_name)
 
     @_deprecate_positional_args
     def ctp(  # type: ignore[misc]
@@ -5235,7 +5257,15 @@ class DataObjectFilters:
         >>> sphere.plot()
 
         """
-        _raise_if_composite_has_pointset(self)
+        # Convert block by block so each block takes the path for its own type
+        if isinstance(self, pv.MultiBlock):
+            return self.generic_filter(
+                'point_data_to_cell_data',
+                pass_point_data=pass_point_data,
+                categorical=categorical,
+                progress_bar=progress_bar,
+            )
+
         alg = _vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(self)
         alg.SetPassPointData(pass_point_data)
@@ -5243,10 +5273,7 @@ class DataObjectFilters:
         _update_alg(
             alg, progress_bar=progress_bar, message='Transforming point data into cell data'
         )
-        active_scalars = None
-        if not isinstance(self, pv.MultiBlock):
-            active_scalars = self.active_scalars_name
-        return _get_output(alg, active_scalars=active_scalars)
+        return _get_output(alg, active_scalars=self.active_scalars_name)
 
     @_deprecate_positional_args
     def ptc(  # type: ignore[misc]
@@ -5789,25 +5816,6 @@ def _composite_has_pointset(dataset: DataSet | MultiBlock) -> bool:
     return isinstance(dataset, pv.MultiBlock) and any(
         isinstance(block, pv.PointSet) for block in dataset.recursive_iterator(skip_none=True)
     )
-
-
-def _raise_if_composite_has_pointset(
-    dataset: DataSet | MultiBlock,
-    error: type[Exception] | None = None,
-) -> None:
-    """Raise if a MultiBlock (recursively) contains a PointSet block.
-
-    Several filters (``cell_data_to_point_data``, ``point_data_to_cell_data``,
-    ``extract_all_edges``, ``compute_cell_sizes``) hand a MultiBlock straight
-    to the underlying :vtk:`vtkAlgorithm`, relying on VTK's own
-    composite-dataset dispatch rather than iterating blocks in Python. On
-    some VTK versions, running these filters on a composite containing a
-    cell-less PointSet block segfaults instead of raising, so guard against
-    it here before ever reaching the algorithm.
-    """
-    if _composite_has_pointset(dataset):
-        error_type = error or pv.core.errors.PointSetNotSupported
-        raise error_type()
 
 
 def _get_cell_quality_measures() -> dict[str, str]:

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1484,9 +1484,9 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
     match = (
         "The filter 'resample'\ncould not be applied to the block at index 1 with name "
-        "'Block-01' and type RectilinearGrid."
+        "'Block-01' and type RectilinearGrid:\n'RectilinearGrid' object has no attribute"
     )
-    with pytest.raises(RuntimeError, match=match):
+    with pytest.raises(AttributeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
@@ -1494,22 +1494,49 @@ def test_generic_filter_raises(multiblock_all_with_nested_and_none):
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
     match = (
         "The filter 'resample'\ncould not be applied to the nested block at index [0][1] "
-        "with name 'Block-01' and type RectilinearGrid."
+        "with name 'Block-01' and type RectilinearGrid:"
     )
-    with pytest.raises(RuntimeError, match=re.escape(match)):
+    with pytest.raises(AttributeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
         )
     # Test with invalid kwargs
     match = "The filter '<bound method DataSetFilters.align_xyz of ImageData"
-    with pytest.raises(RuntimeError, match=re.escape(match)):
+    with pytest.raises(TypeError, match=re.escape(match)):
         multiblock_all_with_nested_and_none.generic_filter('align_xyz', foo='bar')
+
     # Test with function
-    match = "The filter '<function test_generic_filter_raises"
-    with pytest.raises(RuntimeError, match=match):
-        multiblock_all_with_nested_and_none.generic_filter(
-            test_generic_filter_raises,
-        )
+    def fail(block):
+        msg = f'cannot filter {type(block).__name__}'
+        raise ValueError(msg)
+
+    match = "The filter '<function test_generic_filter_raises.<locals>.fail"
+    with pytest.raises(ValueError, match=match):
+        multiblock_all_with_nested_and_none.generic_filter(fail)
+
+
+def test_generic_filter_keeps_error_class(multiblock_all_with_nested_and_none):
+    class BlockError(Exception):
+        pass
+
+    def fail(block):
+        msg = f'cannot filter {type(block).__name__}'
+        raise BlockError(msg)
+
+    match = (
+        "could not be applied to the block at index 0 with name 'Block-00' and type "
+        'ImageData:\ncannot filter ImageData'
+    )
+    with pytest.raises(BlockError, match=match) as info:
+        multiblock_all_with_nested_and_none.generic_filter(fail)
+    assert info.value.__cause__ is None
+
+    # An error without a message gets the block, and nothing else
+    def fail_silently(_):
+        raise BlockError
+
+    with pytest.raises(BlockError, match=r'type ImageData\.$'):
+        multiblock_all_with_nested_and_none.generic_filter(fail_silently)
 
 
 def test_block_types(multiblock_all_with_nested_and_none):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1359,11 +1359,23 @@ def test_extract_all_edges_composite(multiblock_all_no_pointset):
     assert output.n_blocks == multiblock_all_no_pointset.n_blocks
 
 
+def test_cell_validator_composite(multiblock_all_no_pointset):
+    output = multiblock_all_no_pointset.cell_validator()
+    assert output.n_blocks == multiblock_all_no_pointset.n_blocks
+    for block, source in zip(output, multiblock_all_no_pointset, strict=True):
+        assert type(block) is type(source)
+        assert block.active_scalars_name == 'validity_state'
+        assert block.cell_data['validity_state'].shape == (source.n_cells,)
+        assert block.field_data['invalid'].size == 0
+
+
+def test_cell_validator_composite_pointset_raises(multiblock_all):
+    with pytest.raises(pv.PointSetCellOperationError, match='type PointSet'):
+        multiblock_all.cell_validator()
+
+
 def test_extract_all_edges_composite_pointset_raises(multiblock_all):
-    # extract_all_edges hands the whole composite to the underlying VTK
-    # algorithm; on some VTK versions this segfaults instead of raising if a
-    # block is a cell-less PointSet, so PyVista guards against it explicitly.
-    with pytest.raises(pv.PointSetCellOperationError):
+    with pytest.raises(pv.PointSetCellOperationError, match='type PointSet'):
         multiblock_all.extract_all_edges(progress_bar=True)
 
 
@@ -1479,10 +1491,7 @@ def test_compute_cell_sizes_composite(multiblock_all_no_pointset):
 
 
 def test_compute_cell_sizes_composite_pointset_raises(multiblock_all):
-    # compute_cell_sizes hands the whole composite to the underlying VTK
-    # algorithm; on some VTK versions this segfaults instead of raising if a
-    # block is a cell-less PointSet, so PyVista guards against it explicitly.
-    with pytest.raises(pv.PointSetCellOperationError):
+    with pytest.raises(pv.PointSetCellOperationError, match='type PointSet'):
         multiblock_all.compute_cell_sizes(progress_bar=True)
 
 
@@ -1542,10 +1551,7 @@ def test_cell_data_to_point_data_composite(multiblock_all_no_pointset):
 
 
 def test_cell_data_to_point_data_composite_pointset_raises(multiblock_all):
-    # cell_data_to_point_data hands the whole composite to the underlying VTK
-    # algorithm; on some VTK versions this segfaults instead of raising if a
-    # block is a cell-less PointSet, so PyVista guards against it explicitly.
-    with pytest.raises(pv.PointSetNotSupported):
+    with pytest.raises(pv.PointSetNotSupported, match='type PointSet'):
         multiblock_all.cell_data_to_point_data(progress_bar=True)
 
 
@@ -1564,7 +1570,7 @@ def test_point_data_to_cell_data_composite(multiblock_all_no_pointset):
 
 
 def test_point_data_to_cell_data_composite_pointset_raises(multiblock_all):
-    with pytest.raises(pv.PointSetNotSupported):
+    with pytest.raises(pv.PointSetNotSupported, match='type PointSet'):
         multiblock_all.point_data_to_cell_data(progress_bar=True)
 
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1843,7 +1843,7 @@ def test_cell_quality_composite(
     multiblock_all_with_nested_and_none, multiblock_all_no_pointset_with_nested_and_none
 ):
     match = "could not be applied to the block at index 5 with name 'Block-05' and type PointSet"
-    with pytest.raises(RuntimeError, match=match):
+    with pytest.raises(pv.PointSetCellOperationError, match=match):
         qual = multiblock_all_with_nested_and_none.cell_quality([SHAPE])
 
     qual = multiblock_all_no_pointset_with_nested_and_none.cell_quality([SHAPE])
@@ -4077,15 +4077,10 @@ def test_extract_surface_nonlinear(as_multiblock):
     with pytest.raises(ValueError, match=match):
         grid.extract_surface(algorithm='geometry', nonlinear_subdivision=5)
 
+    match = 'Mesh contains non-linear cells which cannot be processed by the geometry algorithm.'
     if as_multiblock:
-        expected_error = RuntimeError
-        match = 'could not be applied to the block at index 0'
-    else:
-        expected_error = ValueError
-        match = (
-            'Mesh contains non-linear cells which cannot be processed by the geometry algorithm.'
-        )
-    with pytest.raises(expected_error, match=match):
+        match = '(?s)could not be applied to the block at index 0.*' + match
+    with pytest.raises(ValueError, match=match):
         grid.extract_surface(algorithm='geometry')
 
     # No subdivision, expect one face per cell


### PR DESCRIPTION
### Overview

Stacked on #9176.

`cell_validator`, `extract_all_edges`, `compute_cell_sizes`, `cell_data_to_point_data` and `point_data_to_cell_data` handed a whole `MultiBlock` to the VTK algorithm, which segfaults when a block is a `PointSet` (`cell_validator` still does on main; the other four had `_raise_if_composite_has_pointset` in front, which rejects the composite without saying which block). They now go through `generic_filter`, so each block takes the path its own class takes: a `PointSet` block raises its own `PointSetCellOperationError` / `PointSetNotSupported` with the block's index and name in the message, and a grid block in `cell_validator` takes the same skip path a bare grid does. The guard is gone; `_composite_has_pointset` stays for `elevation`'s VTK 9.3 check, which #9123 retires.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
