### PR TITLE
Rename 'Docstring Examples' backreference heading to 'API Examples'

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -709,7 +709,7 @@ autocodelink_autodoc_backrefs = True
 # Rename backreferences group headings.
 autocodelink_category_labels = {
     'Sphinx Gallery': 'Gallery Examples',
-    'Docstring Examples': 'Docstring Examples',
+    'Docstring Examples': 'API Examples',
     'Documentation': 'Guides',
 }
 


### PR DESCRIPTION
The "Used In" backreference sections group links under three headings. Two of them, "Guides" and "Gallery Examples", are named after the part of the site they link to. The third, "Docstring Examples", is named after where the source text lives, which means nothing to a reader. This renames it to "API Examples" so all three headings point at a section of the docs.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
