### PR TITLE
Fix stale tile after a scaled screenshot

### DIFF
--- a/pyvista/plotting/utilities/regression.py
+++ b/pyvista/plotting/utilities/regression.py
@@ -110,6 +110,9 @@ def run_image_filter(imfilter: _vtk.vtkWindowToImageFilter) -> _Pixels:
     # Update filter and grab pixels
     imfilter.Modified()
     imfilter.Update()
+    if max(imfilter.GetScale()) > 1:
+        # The tiled capture leaves its last tile in the front buffer.
+        imfilter.GetInput().Render()
     image = cast('ImageData | None', pv.wrap(imfilter.GetOutput()))
     if image is None:
         return np.empty((0, 0, 0), dtype=np.uint8)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1772,6 +1772,20 @@ def test_screenshot_scaled():
 
 
 @pytest.mark.usefixtures('no_images_to_verify')
+def test_screenshot_scaled_restores_window(sphere):
+    pl = pv.Plotter()
+    pl.add_mesh(sphere, scalars=np.arange(sphere.n_points))
+    before = pl.screenshot()
+    assert pl.screenshot(scale=3).shape[:2] == tuple(3 * n for n in before.shape[:2])
+    assert np.array_equal(pl.screenshot(), before)
+    pl.image_scale = 2
+    assert pl.get_image_depth().shape == tuple(2 * n for n in before.shape[:2])
+    pl.image_scale = 1
+    assert np.array_equal(pl.image, before)
+    pl.close()
+
+
+@pytest.mark.usefixtures('no_images_to_verify')
 def test_screenshot_altered_window_size(sphere):
     pl = pv.Plotter()
     pl.add_mesh(sphere)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1777,11 +1777,12 @@ def test_screenshot_scaled_restores_window(sphere):
     pl.add_mesh(sphere, scalars=np.arange(sphere.n_points))
     before = pl.screenshot()
     assert pl.screenshot(scale=3).shape[:2] == tuple(3 * n for n in before.shape[:2])
-    assert np.array_equal(pl.screenshot(), before)
+    # Tolerate sub-LSB pixel noise from non-deterministic renderers.
+    assert pv.compare_images(pl.screenshot(), before) < 1.0
     pl.image_scale = 2
     assert pl.get_image_depth().shape == tuple(2 * n for n in before.shape[:2])
     pl.image_scale = 1
-    assert np.array_equal(pl.image, before)
+    assert pv.compare_images(pl.image, before) < 1.0
     pl.close()
 
 


### PR DESCRIPTION
### Overview

After `pl.screenshot(scale=3)`, a following `pl.screenshot()` returned the zoomed top-right tile of the scene, with 2D actors such as scalar bars missing. `vtkWindowToImageFilter` renders once per tile when the scale is above 1 and restores the cameras and tile state afterwards, but never renders a final full frame, so the last tile stays in the front buffer and the unscaled capture reads it back without re-rendering. This renders the window once after any scaled capture, in `run_image_filter` so a scaled `get_image_depth` is covered too.

Changes drafted by Claude Fable 5.1 but fully understood by me

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
