### PR TITLE
Deprecate setting scalars where an array is required

### DIFF
--- a/doc/source/user-guide/data_model.rst
+++ b/doc/source/user-guide/data_model.rst
@@ -661,7 +661,7 @@ shape. You can even add string arrays in the field data:
 Note that the field data is automatically transferred to VTK C-style
 arrays and then represented as a numpy data format. Field data always
 holds arrays. To attach scalar metadata such as a name, use
-:attr:`user_dict <pyvista.DataObject.user_dict>` instead.
+:attr:`~pyvista.DataObject.user_dict` instead.
 
 When listing the current field data, note that the association is "NONE":
 

--- a/doc/source/user-guide/data_model.rst
+++ b/doc/source/user-guide/data_model.rst
@@ -659,7 +659,9 @@ shape. You can even add string arrays in the field data:
    >>> ugrid.field_data['my-field-data']
 
 Note that the field data is automatically transferred to VTK C-style
-arrays and then represented as a numpy data format.
+arrays and then represented as a numpy data format. Field data always
+holds arrays. To attach scalar metadata such as a name, use
+:attr:`user_dict <pyvista.DataObject.user_dict>` instead.
 
 When listing the current field data, note that the association is "NONE":
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -20,7 +20,6 @@ from pyvista.core._vtk_utilities import vtkPyVistaOverride
 from pyvista.typing.mypy_plugin import promote_type
 
 from .datasetattributes import DataSetAttributes
-from .pyvista_ndarray import pyvista_ndarray
 from .utilities.accessor_registry import _clear_accessor_cache
 from .utilities.accessor_registry import _pending_accessor_names
 from .utilities.accessor_registry import _resolve_pending_accessor
@@ -734,7 +733,7 @@ class DataObject(
         pyvista DataSetAttributes
         Association     : NONE
         Contains arrays :
-            _PYVISTA_USER_DICT      str        "{"name": "ant",..."
+            _PYVISTA_USER_DICT      <U75       (1,)
 
         Since it's field data, the user dict can be saved to file along with the
         mesh and retrieved later.
@@ -775,32 +774,22 @@ class DataObject(
 
     def _config_user_dict(self: Self) -> None:
         """Init serialized dict array and ensure it is added to ``field_data``."""
-        field_data = self.field_data
-
-        if not hasattr(self, '_user_dict'):
-            # Init
-            object.__setattr__(self, '_user_dict', _SerializedDictArray())
-
-        if USER_DICT_KEY in field_data.keys():
-            if isinstance(array := field_data[USER_DICT_KEY], pyvista_ndarray):
-                # When loaded from file, field will be cast as pyvista ndarray
-                # Convert to string and initialize new user dict object from it
-                self._user_dict = _SerializedDictArray(''.join(array))
-            elif isinstance(array, str) and str(self._user_dict) != array:  # type: ignore[unreachable]
-                # Filters may update the field data block separately, e.g.
-                # when copying field data, so we need to capture the new
-                # string and re-init
-                self._user_dict = _SerializedDictArray(array)
-            else:
-                # User dict is correctly configured, do nothing
-                return
-
-        # Set field data array directly instead of calling 'set_array'
-        # This skips the call to '_prepare_array' which will otherwise
-        # do all kinds of casting/conversions and mangle this array
-        self._user_dict.SetName(USER_DICT_KEY)
-        field_data.VTKObject.AddArray(self._user_dict)
-        field_data.VTKObject.Modified()
+        field_data = self.field_data.VTKObject
+        user_dict = getattr(self, '_user_dict', None)
+        array = field_data.GetAbstractArray(USER_DICT_KEY)
+        if array is not None and array is user_dict:
+            return
+        if array is not None:
+            # A loaded or copied array holds the JSON as one value or as one character per value
+            json_str = ''.join(map(array.GetValue, range(array.GetNumberOfValues())))
+            user_dict = _SerializedDictArray(json_str)
+        elif user_dict is None:
+            user_dict = _SerializedDictArray()
+        # Add the array directly so that ``_prepare_array`` does not convert it
+        user_dict.SetName(USER_DICT_KEY)
+        field_data.AddArray(user_dict)
+        field_data.Modified()
+        object.__setattr__(self, '_user_dict', user_dict)
 
     @property
     def memory_address(self: Self) -> str:

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -546,6 +546,10 @@ class DataObject(
     def add_field_data(self: Self, array: ArrayLike[Any], name: str, deep: bool = True) -> None:  # noqa: FBT001, FBT002
         """Add field data.
 
+        .. deprecated:: 0.50
+            Setting a scalar is deprecated. Use
+            :attr:`~pyvista.DataObject.user_dict` to store scalar metadata.
+
         Use field data when size of the data you wish to associate
         with the dataset does not match the number of points or cells
         of the dataset.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -44,6 +44,7 @@ from .utilities.arrays import FieldAssociation
 from .utilities.arrays import FieldLiteral
 from .utilities.arrays import PointLiteral
 from .utilities.arrays import _coerce_pointslike_arg
+from .utilities.arrays import _warn_scalar_array
 from .utilities.arrays import get_array
 from .utilities.arrays import get_array_association
 from .utilities.arrays import parse_field_choice
@@ -1581,6 +1582,7 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             scalars = np.asanyarray(scalars)
 
         if scalars.ndim == 0:
+            _warn_scalar_array(name, None)
             # reshape single scalar values from 0D to 1D so that shape[0] can be indexed
             scalars = scalars.reshape((1,))
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1581,10 +1581,6 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             scalars = np.asanyarray(scalars)
 
         if scalars.ndim == 0:
-            if np.issubdtype(scalars.dtype, np.str_):
-                # Always set scalar strings as field data
-                self.field_data[name] = scalars
-                return
             # reshape single scalar values from 0D to 1D so that shape[0] can be indexed
             scalars = scalars.reshape((1,))
 
@@ -1597,7 +1593,6 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             # Field data must be set explicitly as it could be a point of
             # confusion for new users
             raise_not_matching(scalars, self)
-        return
 
     @property
     def n_arrays(self: Self) -> int:
@@ -1736,18 +1731,14 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             fmt = pv.FLOAT_FORMAT
             result: list[tuple[str, int, str, str, str]] = []
             for name, arr in attrs.items():
-                # Field data can contain str values at runtime despite
-                # DataSetAttributes.items() being typed as -> pyvista_ndarray.
-                # Wrap str so .shape / .dtype are available.
-                coerced = pv.pyvista_ndarray(arr) if isinstance(arr, str) else arr  # type: ignore[redundant-expr,unreachable]
-                ncomp = coerced.shape[1] if coerced.ndim > 1 else 1
-                shape = str(tuple(coerced.shape)) if show_shape else ''
+                ncomp = arr.shape[1] if arr.ndim > 1 else 1
+                shape = str(tuple(arr.shape)) if show_shape else ''
                 range_str = ''
-                if show_range and coerced.size > 0 and np.issubdtype(coerced.dtype, np.number):
-                    lo = fmt.format(np.nanmin(coerced))
-                    hi = fmt.format(np.nanmax(coerced))
+                if show_range and arr.size > 0 and np.issubdtype(arr.dtype, np.number):
+                    lo = fmt.format(np.nanmin(arr))
+                    hi = fmt.format(np.nanmax(arr))
                     range_str = f'[{lo}, {hi}]'
-                result.append((name, ncomp, str(coerced.dtype), shape, range_str))
+                result.append((name, ncomp, str(arr.dtype), shape, range_str))
             return result
 
         vec_assoc = self.active_vectors_info.association

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -18,6 +18,7 @@ from pyvista.core._vtk_utilities import VTKObjectWrapperCheckSnakeCase
 
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation
+from .utilities.arrays import _warn_scalar_array
 from .utilities.arrays import convert_array
 from .utilities.arrays import copy_vtk_array
 from .utilities.misc import _NoNewAttrMixin
@@ -542,6 +543,11 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         * :attr:`active_normals_name`
         * :attr:`active_texture_coordinates_name`
 
+        .. deprecated:: 0.50
+            Setting a scalar is deprecated. Broadcast the value with
+            :func:`numpy.full` to set point or cell data, or use
+            :attr:`~pyvista.DataObject.user_dict` to store scalar metadata.
+
         Parameters
         ----------
         data : ArrayLike[float]
@@ -763,13 +769,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
             array_len = 1 if data.ndim == 0 else data.shape[0]
 
         if data.ndim == 0:
-            if data.dtype.kind == 'U':  # np.str_
-                msg = (
-                    f"Array '{name}' cannot be a scalar string. Use a list of strings "
-                    'to store a string array, or use `user_dict` to store string metadata.'
-                )
-                raise TypeError(msg)
-            # Fixup input array length for scalar input
+            _warn_scalar_array(name, association)
             data = np.full(array_len, data)
         if data.shape[0] != array_len:
             msg = (

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -213,17 +213,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
                 if self.association in [FieldAssociation.POINT, FieldAssociation.CELL]:
                     if name == self.active_vectors_name:
                         arr_type = 'VECTORS'
-                # special treatment for string field data
-                if self.association == FieldAssociation.NONE and isinstance(array, str):  # type: ignore[unreachable]
-                    dtype = 'str'  # type: ignore[unreachable]
-                    # Show the string value itself with a max of 20 characters,
-                    # 18 for string and 2 for quotes
-                    val = f'{array[:15]}...' if len(array) > 18 else array
-                    line = f'{name[:23]:<24}{dtype!s:<11}"{val}"'
-                else:
-                    line = (
-                        f'{name[:23]:<24}{array.dtype!s:<11}{array.shape!s:<20} {arr_type}'.strip()
-                    )
+                line = f'{name[:23]:<24}{array.dtype!s:<11}{array.shape!s:<20} {arr_type}'.strip()
                 lines.append(line)
             array_info = '\n    ' + '\n    '.join(lines)
 
@@ -525,7 +515,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         dataset: DataSet | _vtk.vtkDataSet,
         association: FieldAssociation,
     ) -> pyvista_ndarray:
-        """Return the array viewed as ``bool`` or ``complex``, or a scalar string as ``str``."""
+        """Return the array viewed as ``bool`` or ``complex``."""
         name = vtk_arr.GetName()
         association_name = association.name
         if name in dataset._association_bitarray_names[association_name]:  # type: ignore[union-attr]
@@ -537,9 +527,6 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
                 narray = narray.view(np.complex128)  # type: ignore[assignment]
             # remove singleton dimensions to match the behavior of the rest of 1D VTK arrays
             return narray.squeeze()  # type: ignore[return-value]
-        # Field data holding a string scalar (np.str_) is returned as the string itself
-        if narray.ndim == 0 and association is FieldAssociation.NONE and narray.dtype.kind == 'U':
-            return narray.tolist()
         return narray
 
     @_deprecate_positional_args(allowed=['data', 'name'])
@@ -775,26 +762,27 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         else:
             array_len = 1 if data.ndim == 0 else data.shape[0]
 
-        if data.ndim == 0 and data.dtype.kind == 'U':  # np.str_
-            pass  # Do not reshape string scalars
-        else:
+        if data.ndim == 0:
+            if data.dtype.kind == 'U':  # np.str_
+                msg = (
+                    f"Array '{name}' cannot be a scalar string. Use a list of strings "
+                    'to store a string array, or use `user_dict` to store string metadata.'
+                )
+                raise TypeError(msg)
             # Fixup input array length for scalar input
-            if data.ndim == 0:
-                tmparray = np.empty(array_len, dtype=data.dtype)
-                tmparray.fill(data)
-                data = tmparray
-            if data.shape[0] != array_len:
-                msg = (
-                    f"Invalid array shape. Array '{name}' has length ({data.shape[0]}) "
-                    f'but a length of ({array_len}) was expected.'
-                )
-                raise ValueError(msg)
-            if any(data.shape) and data.size == 0:
-                msg = (
-                    f'Invalid array shape. Empty arrays are not allowed. '
-                    f"Array '{name}' cannot have shape {data.shape}."
-                )
-                raise ValueError(msg)
+            data = np.full(array_len, data)
+        if data.shape[0] != array_len:
+            msg = (
+                f"Invalid array shape. Array '{name}' has length ({data.shape[0]}) "
+                f'but a length of ({array_len}) was expected.'
+            )
+            raise ValueError(msg)
+        if any(data.shape) and data.size == 0:
+            msg = (
+                f'Invalid array shape. Empty arrays are not allowed. '
+                f"Array '{name}' cannot have shape {data.shape}."
+            )
+            raise ValueError(msg)
         # attempt to reuse the existing pointer to underlying VTK data
         if isinstance(data, pyvista_ndarray):
             # pyvista_ndarray already contains the reference to the vtk object

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -20,10 +20,13 @@ import numpy.typing as npt
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._version import _is_deprecation_due
+from pyvista._warn_external import warn_external
 from pyvista.core._vtk_utilities import _MATRIX_GET_DATA_RETURNS_ELEMENTS
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core.errors import AmbiguousDataError
 from pyvista.core.errors import MissingDataError
+from pyvista.core.errors import PyVistaDeprecationWarning
 
 if TYPE_CHECKING:
     from pyvista import DataSet
@@ -271,6 +274,10 @@ def convert_array(  # noqa: PLR0917
 ) -> npt.NDArray[Any] | _vtk.vtkAbstractArray | None:
     """Convert a NumPy array to a :vtk:`vtkDataArray` or vice versa.
 
+    .. deprecated:: 0.50
+        Converting a scalar is deprecated. Pass an array with at least one
+        dimension instead.
+
     Parameters
     ----------
     arr : np.ndarray | :vtk:`vtkDataArray`
@@ -297,6 +304,9 @@ def convert_array(  # noqa: PLR0917
     if not isinstance(arr, np.ndarray):
         # Otherwise input must be a vtkDataArray
         return _vtk_array_to_numpy(cast('_vtk.vtkAbstractArray', arr))
+    if arr.ndim == 0:
+        _warn_scalar_array()
+        arr = arr.reshape(1)
 
     kind = arr.dtype.kind
     if kind == 'O':  # np.object_
@@ -305,9 +315,7 @@ def convert_array(  # noqa: PLR0917
     if kind in 'US':  # np.str_ or np.bytes_
         vtk_data: _vtk.vtkAbstractArray = convert_string_array(arr)
     else:
-        # A scalar is stored as a single-tuple array; numpy_to_vtk makes the data contiguous
-        if arr.ndim == 0:
-            arr = arr.reshape(1)
+        # numpy_to_vtk makes the data contiguous
         vtk_data = _vtk.numpy_to_vtk(num_array=arr, deep=deep, array_type=array_type)
     if isinstance(name, str):
         vtk_data.SetName(name)
@@ -467,6 +475,47 @@ def get_array_association(  # noqa: PLR0917
         return preference_field
     # otherwise return first in order of point -> cell -> field
     return matches[0]
+
+
+_SCALAR_ARRAY_HINTS = {
+    FieldAssociation.POINT: (
+        'Use numpy.full or numpy.broadcast_to to create an array with one value per point.'
+    ),
+    FieldAssociation.CELL: (
+        'Use numpy.full or numpy.broadcast_to to create an array with one value per cell.'
+    ),
+    FieldAssociation.ROW: (
+        'Use numpy.full or numpy.broadcast_to to create an array with one value per row.'
+    ),
+    FieldAssociation.NONE: (
+        'Use user_dict to store scalar metadata, or pass [value] to store a one-element array.'
+    ),
+    None: (
+        'Use numpy.full or numpy.broadcast_to to set point or cell data, '
+        'or use user_dict to store scalar metadata.'
+    ),
+}
+
+
+def _warn_scalar_array(
+    name: str | None = None, association: FieldAssociation | None = None
+) -> None:
+    """Warn that a scalar was given where an array is required."""
+    # deprecated 0.50.0, convert to error in 0.53.0
+    if _is_deprecation_due((0, 53)):  # pragma: no cover
+        msg = 'Convert this deprecation warning into an error.'
+        raise RuntimeError(msg)
+    if name is None:
+        msg = (
+            'Converting a scalar to a VTK array is deprecated. '
+            'Pass an array with at least one dimension instead.'
+        )
+    else:
+        msg = (
+            f"Setting array '{name}' from a scalar is deprecated. "
+            f'{_SCALAR_ARRAY_HINTS[association]}'
+        )
+    warn_external(msg, PyVistaDeprecationWarning)
 
 
 def raise_not_matching(scalars: npt.NDArray[Any], dataset: DataSet | Table) -> None:
@@ -702,15 +751,14 @@ def convert_string_array(
 ) -> npt.NDArray[np.str_] | _vtk.vtkStringArray:
     """Convert a NumPy array of strings to a :vtk:`vtkStringArray` or vice versa.
 
-    A scalar string is stored as an array with a single value.
-
     .. versionchanged:: 0.49
         A two-dimensional array keeps its second axis, held as the components of
         the :vtk:`vtkStringArray`. It was previously flattened. An array with more
         dimensions raises instead of being flattened.
 
-    .. versionchanged:: 0.50
-        A scalar string is converted back as a one-element array instead of a scalar.
+    .. deprecated:: 0.50
+        Converting a scalar string is deprecated. It is stored as a one-element
+        array and converted back as one. Pass a one-dimensional array instead.
 
     Parameters
     ----------
@@ -733,6 +781,9 @@ def convert_string_array(
     """
     arr = np.array(arr) if isinstance(arr, str) else arr
     if isinstance(arr, np.ndarray):
+        if arr.ndim == 0:
+            _warn_scalar_array()
+            arr = arr.reshape(1)
         if arr.ndim > 2:
             msg = f'String array must be at most 2-dimensional, got shape {arr.shape}.'
             raise ValueError(msg)

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -689,15 +689,6 @@ def vtk_id_list_to_array(vtk_id_list: _vtk.vtkIdList) -> NumpyArray[int]:
     return np.fromiter(map(vtk_id_list.GetId, range(n_ids)), dtype=int, count=n_ids)
 
 
-def _set_string_scalar_object_name(vtkarr: _vtk.vtkStringArray) -> None:
-    """Set object name for scalar string arrays."""
-    # This is used as a flag so that scalar arrays can be reshaped later.
-    try:
-        vtkarr.SetObjectName('scalar')
-    except AttributeError:
-        vtkarr.GetObjectName = lambda: 'scalar'  # type: ignore[method-assign]
-
-
 # fmt: off
 # ruff: disable[E501]
 @overload
@@ -711,12 +702,15 @@ def convert_string_array(
 ) -> npt.NDArray[np.str_] | _vtk.vtkStringArray:
     """Convert a NumPy array of strings to a :vtk:`vtkStringArray` or vice versa.
 
-    If a scalar string is provided, it is converted to a :vtk:`vtkCharArray`
+    A scalar string is stored as an array with a single value.
 
     .. versionchanged:: 0.49
         A two-dimensional array keeps its second axis, held as the components of
         the :vtk:`vtkStringArray`. It was previously flattened. An array with more
         dimensions raises instead of being flattened.
+
+    .. versionchanged:: 0.50
+        A scalar string is converted back as a one-element array instead of a scalar.
 
     Parameters
     ----------
@@ -748,10 +742,7 @@ def convert_string_array(
             msg = 'String array contains non-ASCII characters that are not supported by VTK.'
             raise ValueError(msg)
         vtkarr = _vtk.vtkStringArray()
-        if arr.ndim == 0:
-            # The object name marks a scalar input
-            _set_string_scalar_object_name(vtkarr)
-        elif arr.ndim == 2:
+        if arr.ndim == 2:
             # The second axis is stored as components, as it is for numeric arrays
             vtkarr.SetNumberOfComponents(arr.shape[1])
 
@@ -766,11 +757,6 @@ def convert_string_array(
     # longest value; passing dtype='|U' to np.empty defaults to width 1
     # which truncates strings.
     arr_out = np.array(list(map(arr.GetValue, range(arr.GetNumberOfValues()))), dtype='|U')
-    try:
-        if arr.GetObjectName() == 'scalar':
-            return np.array(''.join(arr_out))
-    except AttributeError:
-        pass
     n_components = arr.GetNumberOfComponents()
     if n_components > 1:
         return arr_out.reshape(-1, n_components)
@@ -1057,11 +1043,6 @@ class _SerializedDictArray(DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray): 
         # Init UserDict
         super().__init__(dict_, **kwargs)  # type: ignore[arg-type]
         self._update_string()
-
-        # Flag self as a scalar string
-        # This is only needed so that the Field DatasetAttributes repr
-        # shows this array as `str`
-        _set_string_scalar_object_name(self)
 
     def __getstate__(self: _SerializedDictArray) -> None:
         """Support pickling.

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1238,7 +1238,7 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
             if isinstance(value, _vtk.vtkDataArray):
                 vtk_values = value
             else:
-                values = np.asarray(value)
+                values = np.atleast_1d(value)
                 if values.dtype == np.bool_:
                     values = values.astype(np.uint8)
                 vtk_values = convert_array(values)

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1293,7 +1293,7 @@ def test_move_nested_field_data_to_root_check_duplicate_keys():
 
     # Test nested field data key overrides root field data key
     root = _make_nested_multiblock(
-        root_field_data={NAME1: VALUE1}, nested1_field_data={NAME1: VALUE1}
+        root_field_data={NAME1: [VALUE1]}, nested1_field_data={NAME1: [VALUE1]}
     )
     match = (
         "The field data array 'name1' from nested MultiBlock at index [0] with name 'Block-00'\n"

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -188,7 +188,7 @@ def test_metadata_save(hexbeam, tmpdir):
 def test_save_nested_multiblock_field_data(tmp_path, file_ext):
     filename = 'mesh' + file_ext
     nested = pv.MultiBlock()
-    nested.field_data['foo'] = 'bar'
+    nested.field_data['foo'] = ['bar']
     root = pv.MultiBlock([nested])
 
     # Save the multiblock and expect a warning
@@ -222,12 +222,12 @@ def test_user_dict(data_object_type):
     new_dict = dict(ham='eggs')
     data_object.user_dict = new_dict
     assert data_object.user_dict == new_dict
-    assert data_object.field_data[USER_DICT_KEY] == json.dumps(new_dict)
+    assert data_object.field_data[USER_DICT_KEY].tolist() == [json.dumps(new_dict)]
 
     new_dict = UserDict(test='string')
     data_object.user_dict = new_dict
     assert data_object.user_dict == new_dict
-    assert data_object.field_data[USER_DICT_KEY] == json.dumps(new_dict.data)
+    assert data_object.field_data[USER_DICT_KEY].tolist() == [json.dumps(new_dict.data)]
 
     match = (
         "User dict can only be set with type <class 'dict'> or <class 'collections.UserDict'>."
@@ -312,9 +312,7 @@ def test_user_dict_write_read(tmp_path, make_data_object, ext):
     dict_data = dict(foo='bar')
     data_object.user_dict = dict_data
 
-    dict_field_str = str(data_object.user_dict)
-    field_data_repr = repr(data_object.field_data)
-    assert dict_field_str in field_data_repr
+    assert USER_DICT_KEY in repr(data_object.field_data)
 
     filepath = tmp_path / ('data_object' + ext)
     data_object.save(filepath)
@@ -322,10 +320,16 @@ def test_user_dict_write_read(tmp_path, make_data_object, ext):
     data_object_read = pv.read(filepath)
 
     assert data_object_read.user_dict == dict_data
+    assert USER_DICT_KEY in repr(data_object_read.field_data)
 
-    dict_field_str = str(data_object.user_dict)
-    field_data_repr = repr(data_object.field_data)
-    assert dict_field_str in field_data_repr
+
+def test_user_dict_shallow_copy_of_empty_dict():
+    source = pv.Sphere()
+    assert source.user_dict == {}
+    shallow = source.copy(deep=False)
+    shallow.user_dict['name'] = 'copy'
+    assert shallow.user_dict == {'name': 'copy'}
+    assert source.user_dict == {}
 
 
 def test_user_dict_persists_with_merge_filter():

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -582,7 +582,7 @@ def test_arrows_ndim_raises(mocker: MockerFixture):
 
 def test_set_active_scalars_raises(mocker: MockerFixture):
     sphere = pv.Sphere(radius=math.pi)
-    sphere.point_data[(f := 'foo')] = 1
+    sphere.point_data[(f := 'foo')] = np.ones(sphere.n_points)
 
     m = mocker.patch.object(dataset_module, 'get_array_association')
     m.return_value = 1
@@ -596,7 +596,7 @@ def test_set_active_scalars_raises(mocker: MockerFixture):
 
 def test_set_active_scalars_raises_vtk(mocker: MockerFixture):
     sphere = pv.Sphere(radius=math.pi)
-    sphere.point_data[(f := 'foo')] = 1
+    sphere.point_data[(f := 'foo')] = np.ones(sphere.n_points)
 
     m = mocker.patch.object(sphere, 'GetPointData')
     m().SetActiveScalars.return_value = -1

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -14,6 +14,7 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista import examples
 from pyvista.core import dataset as dataset_module
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.examples import load_airplane
 from pyvista.examples import load_explicit_structured
 from pyvista.examples import load_hexbeam
@@ -164,13 +165,6 @@ def test_point_cell_field_data_empty_array(uniform, attribute, empty_shape, mesh
             data['new_array'] = empty_array
 
 
-def test_point_cell_data_single_scalar_no_exception_raised():
-    m = pv.PolyData([0, 0, 0.0])
-    m.point_data['foo'] = 1
-    m.cell_data['bar'] = 1
-    m['baz'] = 1
-
-
 def test_field_data(hexbeam):
     key = 'test_array_field'
     # Add array of length not equal to n_cells or n_points
@@ -213,17 +207,61 @@ def test_field_data_string(hexbeam):
     assert returned.tolist() == ['bar']
 
 
-def test_field_data_scalar_string_raises(hexbeam):
-    match = "Array 'foo' cannot be a scalar string"
-    with pytest.raises(TypeError, match=match):
-        hexbeam.field_data['foo'] = 'bar'
-    with pytest.raises(TypeError, match=match):
-        hexbeam.add_field_data('bar', 'foo')
-    with pytest.raises(TypeError, match=match):
-        hexbeam.point_data['foo'] = 'bar'
-    with pytest.raises(ValueError, match='Number of scalars'):
-        hexbeam['foo'] = 'bar'
+SCALAR_VALUES = [1, 1.5, True, 'bar', np.float32(2.0), np.array(3)]
+BROADCAST_HINT = 'Use numpy.full or numpy.broadcast_to to create an array with one value per '
+
+
+@pytest.mark.parametrize('value', SCALAR_VALUES)
+@pytest.mark.parametrize(
+    ('attribute', 'hint'),
+    [
+        ('point_data', BROADCAST_HINT + 'point.'),
+        ('cell_data', BROADCAST_HINT + 'cell.'),
+        (
+            'field_data',
+            (
+                'Use user_dict to store scalar metadata, '
+                'or pass [value] to store a one-element array.'
+            ),
+        ),
+    ],
+)
+def test_set_scalar_deprecated(hexbeam, attribute, hint, value):
+    data = getattr(hexbeam, attribute)
+    match = f"Setting array 'foo' from a scalar is deprecated. {hint}"
+    with pytest.warns(PyVistaDeprecationWarning, match=re.escape(match)):
+        data['foo'] = value
+    expected_len = 1 if attribute == 'field_data' else data.valid_array_len
+    assert data['foo'].shape == (expected_len,)
+    assert np.all(data['foo'] == value)
+
+
+@pytest.mark.parametrize('value', SCALAR_VALUES)
+def test_add_field_data_scalar_deprecated(hexbeam, value):
+    match = (
+        "Setting array 'foo' from a scalar is deprecated. Use user_dict to store scalar "
+        'metadata, or pass [value] to store a one-element array.'
+    )
+    with pytest.warns(PyVistaDeprecationWarning, match=re.escape(match)):
+        hexbeam.add_field_data(value, 'foo')
+    assert hexbeam.field_data['foo'].tolist() == [value]
+
+
+@pytest.mark.parametrize('value', SCALAR_VALUES)
+def test_setitem_scalar_deprecated(hexbeam, value):
+    match = (
+        "Setting array 'foo' from a scalar is deprecated. Use numpy.full or numpy.broadcast_to "
+        'to set point or cell data, or use user_dict to store scalar metadata.'
+    )
+    with pytest.warns(PyVistaDeprecationWarning, match=re.escape(match)):
+        with pytest.raises(ValueError, match='Number of scalars'):
+            hexbeam['foo'] = value
     assert 'foo' not in hexbeam.array_names
+
+    single_point = pv.PolyData([0.0, 0.0, 0.0])
+    with pytest.warns(PyVistaDeprecationWarning, match=re.escape(match)):
+        single_point['foo'] = value
+    assert single_point.point_data['foo'].tolist() == [value]
 
 
 @pytest.mark.parametrize('field', [range(5), np.ones((3, 3))[:, 0]])

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -203,35 +203,27 @@ def test_field_data(hexbeam):
 
 
 def test_field_data_string(hexbeam):
-    # test `mesh.field_data`
-    field_name = 'foo'
-    field_value = 'bar'
-    hexbeam.field_data[field_name] = field_value
-    returned = hexbeam.field_data[field_name]
-    assert returned == field_value
-    assert isinstance(returned, str)
-
-    # test `mesh.add_field_data`
-    field_name = 'eggs'
-    field_value = 'ham'
-    hexbeam.add_field_data(array=field_value, name=field_name)
-    returned = hexbeam.field_data[field_name]
-    assert returned == field_value
-    assert isinstance(returned, str)
-
-    # test `mesh[name] = data`
-    field_name = 'baz'
-    field_value = 'a' * hexbeam.n_points
-    hexbeam[field_name] = field_value
-    returned = hexbeam.field_data[field_name]
-    assert returned == field_value
-    assert isinstance(returned, str)
-
-    # a sequence of strings, not only a single one
-    field_name = 'spam'
     field_value = ['I could', 'write', 'notes', 'here']
-    hexbeam.add_field_data(field_value, field_name)
-    assert hexbeam.field_data[field_name].tolist() == field_value
+    hexbeam.add_field_data(field_value, 'spam')
+    assert hexbeam.field_data['spam'].tolist() == field_value
+
+    hexbeam.field_data['foo'] = ['bar']
+    returned = hexbeam.field_data['foo']
+    assert isinstance(returned, np.ndarray)
+    assert returned.tolist() == ['bar']
+
+
+def test_field_data_scalar_string_raises(hexbeam):
+    match = "Array 'foo' cannot be a scalar string"
+    with pytest.raises(TypeError, match=match):
+        hexbeam.field_data['foo'] = 'bar'
+    with pytest.raises(TypeError, match=match):
+        hexbeam.add_field_data('bar', 'foo')
+    with pytest.raises(TypeError, match=match):
+        hexbeam.point_data['foo'] = 'bar'
+    with pytest.raises(ValueError, match='Number of scalars'):
+        hexbeam['foo'] = 'bar'
+    assert 'foo' not in hexbeam.array_names
 
 
 @pytest.mark.parametrize('field', [range(5), np.ones((3, 3))[:, 0]])
@@ -502,10 +494,8 @@ def test_html_repr(hexbeam):
     assert hexbeam._repr_html_() is not None
 
 
-def test_html_repr_string_scalar(hexbeam):
-    array_data = 'data'
-    array_name = 'name'
-    hexbeam.add_field_data(array_data, array_name)
+def test_html_repr_string_array(hexbeam):
+    hexbeam.add_field_data(['data'], 'name')
     assert hexbeam._repr_html_() is not None
 
 

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -117,18 +117,9 @@ def test_repr_field_attributes_with_string(hexbeam_field_attributes):
     assert 'DataSetAttributes' in repr_str
     assert 'Contains arrays : None' in repr_str
 
-    # Add string data
-    str_len_18 = 'stringlength18char'
-    assert len(str_len_18) == 18
-    str_len_19 = 'stringlength19chars'
-    assert len(str_len_19) == 19
-
-    hexbeam_field_attributes['string_data_18'] = str_len_18
-    hexbeam_field_attributes['string_data_19'] = str_len_19
-
+    hexbeam_field_attributes['string_data'] = ['hello', 'world']
     repr_str = str(hexbeam_field_attributes)
-    assert 'string_data_18          str        "stringlength18char"' in repr_str
-    assert 'string_data_19          str        "stringlength19c..."' in repr_str
+    assert 'string_data             <U5        (2,)' in repr_str
 
 
 def test_empty_active_vectors(hexbeam):

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -19,6 +19,7 @@ import pytest
 
 import pyvista as pv
 from pyvista import _vtk
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
 
@@ -209,7 +210,7 @@ def test_active_normals_name():
 
 
 def test_set_scalars(sphere):
-    scalars = np.array(sphere.n_points)
+    scalars = np.arange(sphere.n_points)
     key = 'scalars'
     sphere.point_data.set_scalars(scalars, key)
     assert sphere.point_data.active_scalars_name == key
@@ -403,13 +404,15 @@ def test_set_array_catch(hexbeam):
 @settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(scalar=integers(min_value=-sys.maxsize - 1, max_value=sys.maxsize))
 def test_set_array_should_accept_scalar_value(scalar, hexbeam_point_attributes):
-    hexbeam_point_attributes.set_array(scalar, name='int_array')
+    with pytest.warns(PyVistaDeprecationWarning, match='from a scalar is deprecated'):
+        hexbeam_point_attributes.set_array(scalar, name='int_array')
 
 
 @settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(scalar=integers(min_value=-sys.maxsize - 1, max_value=sys.maxsize))
 def test_set_array_scalar_value_should_give_array(scalar, hexbeam_point_attributes):
-    hexbeam_point_attributes.set_array(scalar, name='int_array')
+    with pytest.warns(PyVistaDeprecationWarning, match='from a scalar is deprecated'):
+        hexbeam_point_attributes.set_array(scalar, name='int_array')
     expected = np.full(hexbeam_point_attributes.dataset.n_points, scalar)
     assert np.array_equal(expected, hexbeam_point_attributes['int_array'])
 

--- a/tests/core/test_formatting_html.py
+++ b/tests/core/test_formatting_html.py
@@ -483,10 +483,9 @@ def test_dataset_repr_active_tcoords_badge():
 
 
 def test_dataset_repr_string_field_data():
-    """String field data exercises the isinstance(arr, str) coercion path
-    and must not crash."""
+    """String field data has no numeric range and must not crash the repr."""
     mesh = pv.Sphere()
-    mesh.field_data['name'] = 'test_string'
+    mesh.field_data['name'] = ['test_string']
     html = mesh._repr_html_()
     assert 'Field Data' in html
     assert 'name' in html

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -27,9 +27,9 @@ def beach():
 
 def variable_dimensionality_image(dimensions):
     image = pv.ImageData(dimensions=dimensions)
-    image.point_data['image'] = 99
-    image.point_data['other'] = 42
-    image.cell_data['data'] = 142
+    image.point_data['image'] = np.full(image.n_points, 99)
+    image.point_data['other'] = np.full(image.n_points, 42)
+    image.cell_data['data'] = np.full(image.n_cells, 142)
     return image
 
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1120,12 +1120,14 @@ def test_convert_array():
     arr4 = pv.core.utilities.arrays.convert_array(my_list)
     assert arr4.GetNumberOfValues() == len(my_list)
 
-    # test string scalar is converted to string array with length on
+    # a scalar string round-trips as a one-element array
     my_str = 'abc'
     arr5 = pv.core.utilities.arrays.convert_array(my_str)
     assert arr5.GetNumberOfValues() == 1
+    assert pv.core.utilities.arrays.convert_array(arr5).tolist() == [my_str]
     arr6 = pv.core.utilities.arrays.convert_array(np.array(my_str))
     assert arr6.GetNumberOfValues() == 1
+    assert pv.core.utilities.arrays.convert_array(arr6).tolist() == [my_str]
 
 
 def test_has_duplicates():
@@ -1757,13 +1759,13 @@ def test_convert_string_array_roundtrip():
 
 
 def test_convert_string_array_scalar_string():
-    """A bare Python str round-trips back to a 0-d numpy array of the original."""
+    """A bare Python str round-trips back as a one-element array."""
     vtk_arr = convert_string_array('hello')
     assert vtk_arr.GetNumberOfValues() == 1
     assert vtk_arr.GetValue(0) == 'hello'
     out = convert_string_array(vtk_arr)
-    assert out.ndim == 0
-    assert str(out) == 'hello'
+    assert out.shape == (1,)
+    assert out.tolist() == ['hello']
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -42,6 +42,7 @@ from pyvista._deprecate_positional_args import _deprecate_positional_args
 from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
 from pyvista.core._vtk_utilities import is_vtk_attribute
 from pyvista.core.celltype import _CELL_TYPE_INFO
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.filters import _update_alg
 from pyvista.core.utilities import cells
 from pyvista.core.utilities import features
@@ -744,11 +745,7 @@ def test_vtkmatrix_from_array_like():
     assert np.array_equal(pv.array_from_vtkmatrix(matrix), strided)
 
 
-def test_convert_array_scalar_and_strided():
-    vtk_scalar = convert_array(np.array(1.5))
-    assert vtk_scalar.GetNumberOfTuples() == 1
-    assert vtk_scalar.GetValue(0) == 1.5
-
+def test_convert_array_strided():
     strided = np.arange(10.0)[::2]
     assert np.array_equal(convert_array(convert_array(strided)), strided)
 
@@ -1120,14 +1117,25 @@ def test_convert_array():
     arr4 = pv.core.utilities.arrays.convert_array(my_list)
     assert arr4.GetNumberOfValues() == len(my_list)
 
-    # a scalar string round-trips as a one-element array
-    my_str = 'abc'
-    arr5 = pv.core.utilities.arrays.convert_array(my_str)
-    assert arr5.GetNumberOfValues() == 1
-    assert pv.core.utilities.arrays.convert_array(arr5).tolist() == [my_str]
-    arr6 = pv.core.utilities.arrays.convert_array(np.array(my_str))
-    assert arr6.GetNumberOfValues() == 1
-    assert pv.core.utilities.arrays.convert_array(arr6).tolist() == [my_str]
+
+CONVERT_SCALAR_MATCH = (
+    'Converting a scalar to a VTK array is deprecated. '
+    'Pass an array with at least one dimension instead.'
+)
+
+
+@pytest.mark.parametrize('value', [1.5, np.array(2), 'abc', np.array('abc')])
+def test_convert_array_scalar_deprecated(value):
+    with pytest.warns(PyVistaDeprecationWarning, match=CONVERT_SCALAR_MATCH):
+        vtk_arr = pv.core.utilities.arrays.convert_array(np.asarray(value))
+    assert vtk_arr.GetNumberOfTuples() == 1
+    assert pv.core.utilities.arrays.convert_array(vtk_arr).tolist() == [np.asarray(value).item()]
+
+
+def test_convert_array_str_deprecated():
+    with pytest.warns(PyVistaDeprecationWarning, match=CONVERT_SCALAR_MATCH):
+        vtk_arr = pv.core.utilities.arrays.convert_array('abc')
+    assert vtk_arr.GetNumberOfValues() == 1
 
 
 def test_has_duplicates():
@@ -1758,9 +1766,10 @@ def test_convert_string_array_roundtrip():
     assert np.array_equal(out, arr)
 
 
-def test_convert_string_array_scalar_string():
-    """A bare Python str round-trips back as a one-element array."""
-    vtk_arr = convert_string_array('hello')
+@pytest.mark.parametrize('value', ['hello', np.array('hello')])
+def test_convert_string_array_scalar_deprecated(value):
+    with pytest.warns(PyVistaDeprecationWarning, match=CONVERT_SCALAR_MATCH):
+        vtk_arr = convert_string_array(value)
     assert vtk_arr.GetNumberOfValues() == 1
     assert vtk_arr.GetValue(0) == 'hello'
     out = convert_string_array(vtk_arr)

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -29,6 +29,12 @@ def test_cmap_values_raises():
         LookupTable(cmap='foo', values='bar')
 
 
+def test_call_numpy_scalar(lut: LookupTable):
+    rgba = lut(np.float32(0.5))
+    assert rgba.shape == (1, 4)
+    assert np.array_equal(rgba, lut([0.5]))
+
+
 def test_call_raises(lut: LookupTable):
     with pytest.raises(
         TypeError,

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -331,7 +331,7 @@ def test_plotter_add_volume_resolution_raises(mocker: MockerFixture):
 def test_plotter_add_volume_mapper_raises():
     pl = pv.Plotter()
     im = pv.ImageData(dimensions=(10, 10, 10))
-    im.point_data['foo'] = 1
+    im.point_data['foo'] = np.ones(im.n_points)
     match = re.escape(
         'Mapper (foo) unknown. Available volume mappers include: '
         'fixed_point, gpu, open_gl, smart, ugrid'

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -94,7 +94,7 @@ def test_add_mesh_isovalue_raises():
 
     pl = pv.Plotter()
     sp = pv.Sphere()
-    sp.cell_data['foo'] = 1
+    sp.cell_data['foo'] = np.ones(sp.n_cells)
     match = re.escape('Contour filter only works on Point data. Array (foo) is in the Cell data.')
     with pytest.raises(TypeError, match=match):
         pl.add_mesh_isovalue(mesh=sp, scalars='foo')

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -204,7 +204,9 @@ def get_default_class_init_kwargs(pyvista_class):
         kwargs['camera'] = pv.Camera()
     elif pyvista_class is pv.Renderer:
         kwargs['parent'] = pv.Plotter()
-    elif pyvista_class in [pv.ChartBox, pv.ChartPie]:
+    elif pyvista_class is pv.ChartBox:
+        kwargs['data'] = [list(range(10))]
+    elif pyvista_class is pv.ChartPie:
         kwargs['data'] = list(range(10))
     elif pyvista_class is pv.CompositeAttributes:
         kwargs['mapper'] = pv.CompositePolyDataMapper()
@@ -236,7 +238,10 @@ def get_default_class_init_kwargs(pyvista_class):
         kwargs['chart'] = pv.charts.Chart2D()
         kwargs['x'] = (0, 0, 0)
         kwargs['ys'] = (1, 0, 0)
-    elif pyvista_class in [pv.charts.BoxPlot, pv.charts.PiePlot]:
+    elif pyvista_class is pv.charts.BoxPlot:
+        kwargs['chart'] = pv.charts.Chart2D()
+        kwargs['data'] = [[0, 0, 0]]
+    elif pyvista_class is pv.charts.PiePlot:
         kwargs['chart'] = pv.charts.Chart2D()
         kwargs['data'] = [0, 0, 0]
     elif pyvista_class is pv.charts._ChartBackground:

--- a/tests/typing/cases/core/convert_array.py
+++ b/tests/typing/cases/core/convert_array.py
@@ -11,10 +11,6 @@ from type_assert import assert_types
 from pyvista import _vtk
 from pyvista.core.utilities.arrays import convert_array
 
-SKIP_RUNTIME = {
-    "convert_array('text')": 'converting a scalar is deprecated',
-}
-
 # A VTK array comes back as NumPy
 assert_types(convert_array(_vtk.vtkFloatArray()), npt.NDArray[Any])
 assert_types(convert_array(_vtk.vtkStringArray()), npt.NDArray[Any])
@@ -25,7 +21,7 @@ assert_types(convert_array(_vtk.vtkFloatArray(), deep=True), npt.NDArray[Any])
 assert_types(convert_array(np.zeros(3)), _vtk.vtkAbstractArray)
 assert_types(convert_array([1, 2, 3]), _vtk.vtkAbstractArray)
 assert_types(convert_array((1.0, 2.0)), _vtk.vtkAbstractArray)
-assert_types(convert_array('text'), _vtk.vtkAbstractArray)  # pragma: no cover
+assert_types(convert_array(['text']), _vtk.vtkAbstractArray)
 assert_types(convert_array(np.zeros(3), 'data'), _vtk.vtkAbstractArray)
 assert_types(convert_array(np.zeros(3), deep=True), _vtk.vtkAbstractArray)
 assert_types(convert_array(np.zeros(3), array_type=_vtk.VTK_UNSIGNED_CHAR), _vtk.vtkAbstractArray)

--- a/tests/typing/cases/core/convert_array.py
+++ b/tests/typing/cases/core/convert_array.py
@@ -11,6 +11,10 @@ from type_assert import assert_types
 from pyvista import _vtk
 from pyvista.core.utilities.arrays import convert_array
 
+SKIP_RUNTIME = {
+    "convert_array('text')": 'converting a scalar is deprecated',
+}
+
 # A VTK array comes back as NumPy
 assert_types(convert_array(_vtk.vtkFloatArray()), npt.NDArray[Any])
 assert_types(convert_array(_vtk.vtkStringArray()), npt.NDArray[Any])
@@ -21,7 +25,7 @@ assert_types(convert_array(_vtk.vtkFloatArray(), deep=True), npt.NDArray[Any])
 assert_types(convert_array(np.zeros(3)), _vtk.vtkAbstractArray)
 assert_types(convert_array([1, 2, 3]), _vtk.vtkAbstractArray)
 assert_types(convert_array((1.0, 2.0)), _vtk.vtkAbstractArray)
-assert_types(convert_array('text'), _vtk.vtkAbstractArray)
+assert_types(convert_array('text'), _vtk.vtkAbstractArray)  # pragma: no cover
 assert_types(convert_array(np.zeros(3), 'data'), _vtk.vtkAbstractArray)
 assert_types(convert_array(np.zeros(3), deep=True), _vtk.vtkAbstractArray)
 assert_types(convert_array(np.zeros(3), array_type=_vtk.VTK_UNSIGNED_CHAR), _vtk.vtkAbstractArray)

--- a/tests/typing/cases/core/convert_string_array.py
+++ b/tests/typing/cases/core/convert_string_array.py
@@ -9,10 +9,6 @@ from type_assert import assert_types
 from pyvista import _vtk
 from pyvista.core.utilities.arrays import convert_string_array
 
-SKIP_RUNTIME = {
-    "convert_string_array('text')": 'converting a scalar string is deprecated',
-}
-
 
 def a_vtk_string_array() -> _vtk.vtkStringArray:
     """Return a two-value VTK string array."""
@@ -26,6 +22,5 @@ def a_vtk_string_array() -> _vtk.vtkStringArray:
 assert_types(convert_string_array(a_vtk_string_array()), npt.NDArray[np.str_])
 assert_types(convert_string_array(a_vtk_string_array(), 'data'), npt.NDArray[np.str_])
 
-assert_types(convert_string_array('text'), _vtk.vtkStringArray)  # pragma: no cover
 assert_types(convert_string_array(np.array(['a', 'b'])), _vtk.vtkStringArray)
 assert_types(convert_string_array(np.array(['a']), 'data'), _vtk.vtkStringArray)

--- a/tests/typing/cases/core/convert_string_array.py
+++ b/tests/typing/cases/core/convert_string_array.py
@@ -9,6 +9,10 @@ from type_assert import assert_types
 from pyvista import _vtk
 from pyvista.core.utilities.arrays import convert_string_array
 
+SKIP_RUNTIME = {
+    "convert_string_array('text')": 'converting a scalar string is deprecated',
+}
+
 
 def a_vtk_string_array() -> _vtk.vtkStringArray:
     """Return a two-value VTK string array."""
@@ -22,6 +26,6 @@ def a_vtk_string_array() -> _vtk.vtkStringArray:
 assert_types(convert_string_array(a_vtk_string_array()), npt.NDArray[np.str_])
 assert_types(convert_string_array(a_vtk_string_array(), 'data'), npt.NDArray[np.str_])
 
-assert_types(convert_string_array('text'), _vtk.vtkStringArray)
+assert_types(convert_string_array('text'), _vtk.vtkStringArray)  # pragma: no cover
 assert_types(convert_string_array(np.array(['a', 'b'])), _vtk.vtkStringArray)
 assert_types(convert_string_array(np.array(['a']), 'data'), _vtk.vtkStringArray)


### PR DESCRIPTION
Setting a scalar where an array is expected now emits a `PyVistaDeprecationWarning` and will raise in 0.53. The warning names the array and says what to do instead: broadcast with `numpy.full` or `numpy.broadcast_to` for `point_data`, `cell_data` and row data, use `user_dict` (or `[value]`) for `field_data`, and either of those for `mesh[name] = value`. `convert_array` and `convert_string_array` warn on 0-d input too, so scalars are refused at every layer once the deprecation lands. Until then a numeric scalar still broadcasts as it does today, so `mesh.point_data['foo'] = 0` keeps working with a warning.

The scalar-string special case from #5747 is gone outright: a scalar string is stored and read back as a one-element array like any other scalar, which is what survives a file round trip. That removes the `vtkStringArray` object-name marker and the `str` branches in both reprs, and `user_dict` now recognises its own array in field data by identity instead of reading the JSON back. A side effect is that writes to a mesh sharing an empty user dict array with its source are no longer lost.

- One helper, `_warn_scalar_array`, carries every message and the single 0.53 removal reminder.
- The two mechanical commits move test call sites that set scalars to explicit arrays.
- `set_array`, `add_field_data` and the two converters carry `.. deprecated:: 0.50` notes; the data model guide points at `user_dict` for scalar metadata.

Resolves #8667
Resolves #7076
Closes #8205

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
