### PR TITLE
Check example dataset source URLs in the weekly linkcheck

### DIFF
--- a/.github/scripts/dataset_urls.py
+++ b/.github/scripts/dataset_urls.py
@@ -1,0 +1,21 @@
+"""Print the source URL of every downloadable example, one per line, for lychee."""
+
+# ruff: noqa: INP001
+from __future__ import annotations
+
+import sys
+from typing import get_args
+
+from pyvista.examples._dataset_loader import _DOWNLOADABLE_TYPES
+from pyvista.examples._get_example import ExampleName
+from pyvista.examples._get_example import _get_dataset_loader
+
+urls: set[str] = set()
+for name in get_args(ExampleName):
+    loader, _, _ = _get_dataset_loader(name)
+    if isinstance(loader, _DOWNLOADABLE_TYPES):
+        urls.update(loader.web_urls)
+
+if not urls:
+    sys.exit('No example dataset URLs found.')
+sys.stdout.write('\n'.join(sorted(urls)) + '\n')

--- a/.github/scripts/dataset_urls.py
+++ b/.github/scripts/dataset_urls.py
@@ -1,24 +1,30 @@
-"""Print the web URL of every downloadable example, one per line, for lychee."""
+"""Write the web URLs of every downloadable example, one file per loader, for lychee."""
 
 from __future__ import annotations
 
+from pathlib import Path
 import sys
 
 from pyvista.examples._dataset_loader import _DOWNLOADABLE_TYPES
 from pyvista.examples._get_example import _supported_modules
 
 
-def main() -> None:
-    """Collect the URLs of every downloadable loader and print them sorted."""
-    urls: set[str] = set()
+def main(directory: Path) -> None:
+    """Write each loader's URLs to ``<module>.<loader>.txt`` under ``directory``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    written = 0
     for module in _supported_modules():
-        for loader in vars(module).values():
-            if isinstance(loader, _DOWNLOADABLE_TYPES):
-                urls.update(loader.web_urls)
-    if not urls:
-        sys.exit('No example dataset URLs found.')
-    print('\n'.join(sorted(urls)))
+        prefix = module.__name__.rpartition('.')[2]
+        for name, loader in vars(module).items():
+            if isinstance(loader, _DOWNLOADABLE_TYPES) and loader.web_urls:
+                path = directory / f'{prefix}.{name}.txt'
+                path.write_text('\n'.join(loader.web_urls) + '\n')
+                written += 1
+    if not written:
+        sys.exit('No example dataset loaders found.')
 
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) != 2:
+        sys.exit(f'usage: {sys.argv[0]} DIRECTORY')
+    main(Path(sys.argv[1]))

--- a/.github/scripts/dataset_urls.py
+++ b/.github/scripts/dataset_urls.py
@@ -1,21 +1,24 @@
-"""Print the source URL of every downloadable example, one per line, for lychee."""
+"""Print the web URL of every downloadable example, one per line, for lychee."""
 
-# ruff: noqa: INP001
 from __future__ import annotations
 
 import sys
-from typing import get_args
 
 from pyvista.examples._dataset_loader import _DOWNLOADABLE_TYPES
-from pyvista.examples._get_example import ExampleName
-from pyvista.examples._get_example import _get_dataset_loader
+from pyvista.examples._get_example import _supported_modules
 
-urls: set[str] = set()
-for name in get_args(ExampleName):
-    loader, _, _ = _get_dataset_loader(name)
-    if isinstance(loader, _DOWNLOADABLE_TYPES):
-        urls.update(loader.web_urls)
 
-if not urls:
-    sys.exit('No example dataset URLs found.')
-sys.stdout.write('\n'.join(sorted(urls)) + '\n')
+def main() -> None:
+    """Collect the URLs of every downloadable loader and print them sorted."""
+    urls: set[str] = set()
+    for module in _supported_modules():
+        for loader in vars(module).values():
+            if isinstance(loader, _DOWNLOADABLE_TYPES):
+                urls.update(loader.web_urls)
+    if not urls:
+        sys.exit('No example dataset URLs found.')
+    print('\n'.join(sorted(urls)))
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -46,7 +46,7 @@ jobs:
         # lychee reads files, so it never sees the URLs the example loaders build at runtime.
         run: |
           pip install -q .
-          python .github/scripts/dataset_urls.py > "$RUNNER_TEMP/dataset-urls.txt"
+          python .github/scripts/dataset_urls.py "$RUNNER_TEMP/dataset-urls"
 
       - name: "Compute weekly cache key"
         id: cachekey
@@ -72,9 +72,16 @@ jobs:
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
           # Only 200 passes here: an accepted 429 would pass a missing dataset, so it is retried instead.
-          args: "--accept 200 ${{ runner.temp }}/dataset-urls.txt"
+          args: "--accept 200 ${{ runner.temp }}/dataset-urls"
           output: lychee/datasets.md
           fail: false
+
+      - name: "Upload example dataset URLs"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dataset-urls
+          path: ${{ runner.temp }}/dataset-urls
 
       - name: "Report Failure"
         if: steps.lychee.outputs.exit_code != 0 || steps.datasets.outputs.exit_code != 0

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -38,6 +38,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: "Collect example dataset URLs"
+        # lychee reads files, so it never sees the URLs the example loaders build at runtime.
+        run: |
+          pip install -q .
+          python .github/scripts/dataset_urls.py > "$RUNNER_TEMP/dataset-urls.txt"
+
       - name: "Compute weekly cache key"
         id: cachekey
         # Rotate the cache weekly so a stale entry cannot pin the job to a
@@ -54,7 +64,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
-          args: "."
+          args: ". ${{ runner.temp }}/dataset-urls.txt"
           fail: false
 
       - name: "Report Failure"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -64,11 +64,20 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
         with:
-          args: ". ${{ runner.temp }}/dataset-urls.txt"
+          args: "."
+          fail: false
+
+      - name: "Check example dataset URLs"
+        id: datasets
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
+        with:
+          # Only 200 passes here: an accepted 429 would pass a missing dataset, so it is retried instead.
+          args: "--accept 200 ${{ runner.temp }}/dataset-urls.txt"
+          output: lychee/datasets.md
           fail: false
 
       - name: "Report Failure"
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0 || steps.datasets.outputs.exit_code != 0
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -85,7 +94,7 @@ jobs:
             /^## Redirects per input/ {skip=1; next}
             skip && /^##? [^#]/ {skip=0}
             !skip
-          ' ./lychee/out.md)
+          ' ./lychee/out.md ./lychee/datasets.md)
 
           body=$(cat <<EOF
           See [the linkcheck run](${RUN_URL}) for the full output.
@@ -104,7 +113,10 @@ jobs:
           fi
 
       - name: "Exit Action"
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0 || steps.datasets.outputs.exit_code != 0
         env:
           LYCHEE_EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
-        run: exit "$LYCHEE_EXIT_CODE"
+          DATASETS_EXIT_CODE: ${{ steps.datasets.outputs.exit_code }}
+        run: |
+          [ "$LYCHEE_EXIT_CODE" != 0 ] && exit "$LYCHEE_EXIT_CODE"
+          exit "$DATASETS_EXIT_CODE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ test = [
   'pyvista-stl>=0.5.3,<0.6.0',
   'pyvista-zstd>=0.3.1,<0.5.0',
   'refleak>=0.2.2,<0.3.0',
-  'retry-requests<2.1.0',
   'scipy<1.17.0',
   'sphinx-autocodelink==0.11.3',
   'sphinx-autoopengraph<0.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -589,6 +589,7 @@ pyvista = "pv"
 '*/conf.py' = ['E402']
 # A command-line script bundled with an agent skill, not an importable package.
 '.claude/skills/*/scripts/*.py' = ['INP', 'T20']
+'.github/scripts/*.py' = ['INP', 'T20'] # CI script, not a package
 '__init__.py' = ['PLC0414']
 'benchmarks/*' = ['ANN', 'S101']
 'doc/*' = ['ANN', 'INP', 'PLC0415']

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import os
 from pathlib import Path
@@ -9,8 +8,6 @@ import re
 import threading
 
 import pytest
-import requests
-from retry_requests import retry
 
 import pyvista as pv
 from pyvista import examples
@@ -43,42 +40,6 @@ def pytest_generate_tests(metafunc):
 def test_dataset_loader_name_matches_download_name(test_case: DatasetLoaderTestCase):
     if (msg := _get_mismatch_fail_msg(test_case)) is not None:  # pragma: no cover -- failure path
         pytest.fail(msg)
-
-
-def _is_valid_url(session: requests.Session, url: str) -> bool:
-    try:
-        # HEAD checks that the file is served without downloading it
-        session.head(url, allow_redirects=True).raise_for_status()
-    except requests.RequestException:
-        return False
-    else:
-        return True
-
-
-@pytest.fixture(scope='module')
-def url_session():
-    """One session for every URL check, so connections are reused across tests."""
-    return retry(
-        status_to_retry=[500, 502, 504, 403, 429],  # default + GH rate limit (403, 429)
-        retries=5,
-        backoff_factor=2.0,
-    )
-
-
-def test_dataset_loader_source_urls_blob(test_case: DatasetLoaderTestCase, url_session):
-    sources = test_case.dataset_loader[1].source_urls
-
-    def is_valid(url: str) -> bool:
-        # Check is_file() in case local cache of pyvista/data is used
-        return Path(url).is_file() or _is_valid_url(url_session, url)
-
-    # Test valid url; some datasets have dozens of files, so check them concurrently
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        valid = pool.map(is_valid, sources)
-        invalid = [url for url, ok in zip(sources, valid, strict=True) if not ok]
-    if invalid:  # pragma: no cover -- failure path
-        urls = '\n'.join(invalid)
-        pytest.fail(f'Invalid blob URL for {test_case.dataset_name}:\n{urls}')
 
 
 def test_delete_downloads(tmpdir):


### PR DESCRIPTION
### Overview

The example loaders build their download URLs at runtime, so the weekly lychee scan never saw them, and the pytest check that did was a no-op on CI, where the restored `pyvista/data` cache turns `source_urls` into local paths. The linkcheck job now writes every downloadable loader's `web_urls` to one file per loader with `.github/scripts/dataset_urls.py` and checks that directory in a second lychee step, so a missing dataset shows up in the same weekly report and `linkcheck-failure` issue under a heading that names the loader, and the directory is kept as a run artifact.

- The dataset step accepts only 200. The tree scan accepts 429 so a throttled docs host is not a weekly failure, but an accepted 429 here would pass a missing dataset, so lychee retries it instead.
- Sweeping loader objects rather than example names also covers the high-resolution and zoomed variants the old test skipped.
- Blob URLs rather than raw ones, since lychee sends GET and raw URLs would download every file; lychee's GitHub API fallback still reports a missing file in a public repository as an error.
- The pytest check and `retry-requests`, which nothing else used, are removed. Supersedes the dataset-URL part of #9150.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
