### PR TITLE
Use `setup-headless-display-action` instead of `xvfb-run` on Linux

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,9 +94,12 @@ jobs:
           python-version: 3.14
           cache: "pip"
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
+
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         with:
-          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime xvfb
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -108,7 +111,7 @@ jobs:
         run: pip install tox-uv
 
       - name: Build Documentation
-        run: timeout 3600 xvfb-run -a tox run -e docs-build
+        run: timeout 3600 tox run -e docs-build
 
       # Build a development wheel and bundle a PEP 503 simple index into the
       # docs output. Once the docs deploy to dev.pyvista.org, users can

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -46,14 +46,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Setup headless display on Windows
-        if: runner.os == 'Windows'
+      - name: Set up headless display
         uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
 
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         if: runner.os == 'Linux'
         with:
-          packages: xvfb libgl1 libglx-mesa0 libosmesa6
+          packages: libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -64,12 +63,7 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      - name: Test Package Docstrings (Linux)
-        if: runner.os == 'Linux'
-        run: xvfb-run -a tox run -e doctest-modules
-
-      - name: Test Package Docstrings (Windows)
-        if: runner.os == 'Windows'
+      - name: Test Package Docstrings
         run: tox run -e doctest-modules
 
   doctest-names:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -179,9 +179,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
+
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         with:
-          packages: xvfb libgl1 libglx-mesa0 libosmesa6
+          packages: libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -201,7 +204,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           TOX_ENV: ${{ env.TOX_FACTOR }}-cov-plotting
-        run: xvfb-run tox run -e "$TOX_ENV"
+        run: tox run -e "$TOX_ENV"
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -257,9 +260,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
+
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         with:
-          packages: xvfb libgl1 libglx-mesa0 libosmesa6
+          packages: libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -279,7 +285,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           TOX_ENV: py${{ matrix.python-version }}-cov-plotting-vtk_dev
-        run: xvfb-run tox run -e "$TOX_ENV"
+        run: tox run -e "$TOX_ENV"
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -309,9 +309,12 @@ jobs:
       # ALL STEPS ABOVE SHOULD BE EXACTLY THE SAME FOR EACH OS
       # ALL STEPS BELOW SHOULD MIMIC THE UNIT TESTING WORKFLOW EXACTLY
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@c103a2ff45650d38cb71684b5dc6cdfeb9442c79
+
       - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9
         with:
-          packages: xvfb libgl1 libglx-mesa0 libosmesa6
+          packages: libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -332,7 +335,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           TOX_ENV: py${{ matrix.python-version }}-plotting-vtk_local
-        run: xvfb-run tox run -e "$TOX_ENV" 2>&1 | tee plotting-test.log
+        run: tox run -e "$TOX_ENV" 2>&1 | tee plotting-test.log
 
       - name: Upload failure summary
         if: failure()


### PR DESCRIPTION
### Overview

The `docstringcheck` flake that ends in `1699 passed, 3 skipped, 1 error` on `bad X server connection. DISPLAY=:99` (e.g. [this run](https://github.com/pyvista/pyvista/actions/runs/34509186424/job/102980103963), 4 of the 63 PR runs since #9091) is Xvfb resetting itself when its last client disconnects: the reset also closes any client that connected in the meantime but hasn't had its setup request answered, so that client's `XOpenDisplay` returns NULL. VTK does exactly that connect whenever a process goes from zero to one render window, both xdist workers do it at the same instant at session start, and VTK 9.7 never retries X in that process afterwards. user27182/pyvista#4 isolates it (4 processes opening and closing the display fail 45–73 times per 1200 against Xvfb's defaults, 0 with `-noreset`, with the server's audit log showing that many clients dropped before ever being accepted).

The fix is `-noreset`, which pyvista/setup-headless-display-action#56 adds. This moves every Linux job that still starts its own server through `xvfb-run` onto the action, the way the Windows jobs already work, so the flag comes from one place; `libosmesa6` stays in the apt cache step because the action doesn't install it. Pinned to v5.1.0 for now, to be bumped once #56 is released.

Changes drafted by Claude Fable 5.1 but fully understood by me

🤖 Generated with [Claude Code](https://claude.com/claude-code)
