### PR TITLE
Fix the dataset gallery's `Reader` field and filter

### DIFF
--- a/doc/source/_static/dataset_gallery_filter.js
+++ b/doc/source/_static/dataset_gallery_filter.js
@@ -23,13 +23,16 @@
         }
       });
     });
-    // "na" is always first, if present - the explicit order list only covers real values.
-    const rest = Array.from(present).filter((v) => v !== "na");
+    // "na" slugs are always first - the explicit order list only covers real values.
+    const isNa = (v) => v === "na" || v.indexOf("na-") === 0;
+    const values = Array.from(present);
+    const na = values.filter(isNa).sort();
+    const rest = values.filter((v) => !isNa(v));
     const explicitOrder = order[facet];
     const ordered = explicitOrder
       ? explicitOrder.filter((v) => rest.includes(v))
       : rest.sort();
-    return present.has("na") ? ["na", ...ordered] : ordered;
+    return [...na, ...ordered];
   }
 
   function buildPanel(dropdown, facet, values, labels, onChange) {

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1886,11 +1886,11 @@ def _get_fullname(typ: type[Any]) -> str:
 def _facet_slugify(text: str) -> str:
     """Turn a facet label into a CSS-class-safe slug, e.g. ``POLY_LINE`` -> ``poly-line``.
 
-    Dashes underscores too, matching what docutils' class-option parser does
-    to `:class-card:` on its own, so the slug agrees with the rendered class.
+    Dashes underscores and dots too, matching what docutils' class-option parser
+    does to `:class-card:` on its own, so the slug agrees with the rendered class.
     """
     text = re.sub(r'(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])', '-', text)
-    return text.lower().replace(' ', '-').replace('_', '-')
+    return text.lower().replace(' ', '-').replace('_', '-').replace('.', '-')
 
 
 def _facet_size_bin(total_size_bytes: int | None) -> tuple[str, str] | None:
@@ -1902,6 +1902,13 @@ def _facet_size_bin(total_size_bytes: int | None) -> tuple[str, str] | None:
         if size_mb < edge:
             return label, slug
     return DATASET_GALLERY_SIZE_BINS[-1][1], DATASET_GALLERY_SIZE_BINS[-1][2]
+
+
+def _no_reader_bin(loader: _DatasetLoader | _FileProps) -> tuple[str, str]:
+    """Return the (label, slug) saying why a loader with no reader has none."""
+    if isinstance(loader, _FileProps):
+        return 'N/A (read in code)', 'na-read-in-code'
+    return 'N/A (generated in code)', 'na'
 
 
 def _ljust_lines(lines: list[str], min_width=None) -> list[str]:
@@ -2590,12 +2597,13 @@ class DatasetCard:
         else:
             add('ctype', 'N/A (no cells)', slug='na')
 
-        reader_types = DatasetPropsGenerator._try_getattr(loader, 'unique_reader_types')
-        if reader_types:
-            for reader_type in reader_types:
-                add('reader', reader_type.__name__)
-        else:
-            add('reader', 'N/A (generated in code)', slug='na')
+        reader_types, companion_names = DatasetPropsGenerator._reader_names(loader)
+        for reader_type in reader_types:
+            add('reader', reader_type.__name__)
+        for name in companion_names:
+            add('reader', name)
+        if not reader_types and not companion_names:
+            add('reader', *_no_reader_bin(loader))
 
         # Uses DATASET_GALLERY_SIZE_BINS' own slugs so bins sort numerically, not alphabetically.
         file_sizes = DatasetPropsGenerator._try_getattr(loader, '_file_sizes')
@@ -2726,14 +2734,29 @@ class DatasetPropsGenerator:
         return None
 
     @staticmethod
+    def _reader_names(
+        loader: _DatasetLoader | _FileProps,
+    ) -> tuple[tuple[type[pv.BaseReader[Any]], ...], tuple[str, ...]]:
+        """Return the loader's built-in reader types and its companion-package reader names."""
+        get = DatasetPropsGenerator._try_getattr
+        return (
+            get(loader, 'unique_reader_types') or (),
+            get(loader, 'unique_companion_reader_names') or (),
+        )
+
+    @staticmethod
     def generate_reader_type(
         loader: _FileProps,
     ):
         """Format reader type(s) with doc references to reader class(es)."""
-        reader_types = DatasetPropsGenerator._try_getattr(loader, 'unique_reader_types')
-        if not reader_types:
-            return '``N/A (generated in code)``'
-        return '\n'.join(f':class:`~{_get_fullname(cls)}`' for cls in reader_types)
+        reader_types, companion_names = DatasetPropsGenerator._reader_names(loader)
+        fields = [f':class:`~{_get_fullname(cls)}`' for cls in reader_types]
+        # A companion package's reader is outside the pyvista API, so there is no page for it.
+        fields += [f'``{name}``' for name in companion_names]
+        if fields:
+            return '\n'.join(fields)
+        label, _ = _no_reader_bin(loader)
+        return f'``{label}``'
 
     @staticmethod
     def generate_importer_method(

--- a/pyvista/core/utilities/_optional_formats.py
+++ b/pyvista/core/utilities/_optional_formats.py
@@ -72,6 +72,12 @@ def _format_for(ext: str, side: _Side) -> _OptionalFormat | None:
     return fmt
 
 
+def _declared_reader_class(ext: str) -> str | None:
+    """Return the reader class name a companion package declares for reading ``ext``."""
+    fmt = _format_for(ext, _READ)
+    return None if fmt is None else fmt.reader_class
+
+
 def _installed_extensions(side: _Side) -> set[str]:
     """Return every extension optional on ``side`` whose package looks importable."""
     installed = set()

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -22,7 +22,7 @@ import pooch
 
 from pyvista._warn_external import warn_external
 from pyvista.core.utilities._optional_formats import _READ
-from pyvista.core.utilities._optional_formats import _format_for
+from pyvista.core.utilities._optional_formats import _declared_reader_class
 from pyvista.core.utilities._optional_formats import _import_handler
 from pyvista.core.utilities._optional_formats import _installed_extensions
 from pyvista.core.utilities._optional_formats import _missing_message
@@ -489,11 +489,8 @@ def _missing_reader_message(ext: str, filename: str | None = None) -> str | None
 
 def _optional_reader_class_name(ext: str) -> str | None:
     """Return the reader class an optional format exposes, when it is importable."""
-    fmt = _format_for(ext, _READ)
-    if fmt is None:
-        return None
     handler, _ = _import_handler(ext, _READ)
-    return fmt.reader_class if handler is not None else None
+    return _declared_reader_class(ext) if handler is not None else None
 
 
 def _resolve_optional_reader(ext: str) -> bool:

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -44,6 +44,7 @@ from typing import cast
 from typing import final
 
 import pyvista as pv
+from pyvista.core.utilities._optional_formats import _declared_reader_class
 from pyvista.core.utilities.fileio import get_ext
 
 if TYPE_CHECKING:
@@ -112,6 +113,16 @@ class _FileProps:
     def unique_reader_types(self) -> tuple[type[pv.BaseReader[Any]], ...]:
         """Return unique reader types from all file readers."""
         return _get_unique_reader_types(self._readers)
+
+    @property
+    def unique_companion_reader_names(self) -> tuple[str, ...]:
+        """Return the names of companion-package reader classes serving these files."""
+        names = {
+            name
+            for ext in self.unique_extensions
+            if (name := _declared_reader_class(ext)) is not None
+        }
+        return tuple(sorted(names))
 
 
 class _Downloadable(Protocol):

--- a/tests/doc/test_tables.py
+++ b/tests/doc/test_tables.py
@@ -5,10 +5,15 @@ import cmocean
 from colorcet import all_original_names
 from colorcet import get_aliases
 import docutils.nodes
+from docutils.parsers.rst.directives import class_option
 import matplotlib as mpl
 import pytest
 
 from doc.source import make_tables
+import pyvista as pv
+from pyvista.examples._dataset_loader import _DatasetLoader
+from pyvista.examples._dataset_loader import _MultiFileDatasetLoader
+from pyvista.examples._dataset_loader import _SingleFileDatasetLoader
 
 CMAP_SET_MISMATCH_ERROR_MSG = (
     'Colormaps in documentation differ from colormaps available. '
@@ -178,3 +183,64 @@ def test_update_image_placeholders_existing(monkeypatch, tmp_path):
     make_tables._update_image_placeholders(node)
 
     assert node['uri'].endswith(expected.name)
+
+
+@pytest.mark.parametrize(
+    ('filename', 'field', 'slug', 'label'),
+    [
+        (
+            'mesh.vtp',
+            ':class:`~pyvista.core.utilities.reader.XMLPolyDataReader`',
+            'reader-xml-poly-data-reader',
+            'XMLPolyDataReader',
+        ),
+        (
+            'mesh.frd',
+            '``pyvista_frd.FRDReader``',
+            'reader-pyvista-frd-frd-reader',
+            'pyvista_frd.FRDReader',
+        ),
+        ('mesh.npy', '``N/A (read in code)``', 'reader-na-read-in-code', 'N/A (read in code)'),
+        ('cubemap/', '``N/A (read in code)``', 'reader-na-read-in-code', 'N/A (read in code)'),
+        (None, '``N/A (generated in code)``', 'reader-na', 'N/A (generated in code)'),
+    ],
+)
+def test_dataset_card_reader_field(tmp_path, filename, field, slug, label):
+    """Each reader state gets its own card field, facet slug and facet label."""
+    if filename is None:
+        loader = _DatasetLoader(pv.Sphere)
+    else:
+        path = tmp_path / filename
+        if filename.endswith('/'):
+            path.mkdir()
+            (path / 'posx.jpg').touch()
+        else:
+            path.touch()
+        loader = _SingleFileDatasetLoader(str(path))
+
+    assert make_tables.DatasetPropsGenerator.generate_reader_type(loader) == field
+
+    classes, labels = make_tables.DatasetCard._generate_facet_classes(loader, pv.examples.examples)
+    reader_classes = [cls for cls in classes.split() if cls.startswith('reader-')]
+    assert reader_classes == [slug]
+    assert labels[slug] == label
+    assert class_option(slug) == [slug]
+
+
+def test_dataset_card_reader_field_mixed(tmp_path):
+    """A loader with both kinds of file lists both readers rather than one N/A."""
+    paths = [tmp_path / 'mesh.vtp', tmp_path / 'mesh.frd']
+    for path in paths:
+        path.touch()
+
+    def _files_func():
+        return tuple(_SingleFileDatasetLoader(str(path)) for path in paths)
+
+    loader = _MultiFileDatasetLoader(_files_func)
+    assert make_tables.DatasetPropsGenerator.generate_reader_type(loader) == (
+        ':class:`~pyvista.core.utilities.reader.XMLPolyDataReader`\n``pyvista_frd.FRDReader``'
+    )
+
+    classes, _ = make_tables.DatasetCard._generate_facet_classes(loader, pv.examples.examples)
+    reader_classes = [cls for cls in classes.split() if cls.startswith('reader-')]
+    assert reader_classes == ['reader-xml-poly-data-reader', 'reader-pyvista-frd-frd-reader']

--- a/tests/examples/test_dataset_loader.py
+++ b/tests/examples/test_dataset_loader.py
@@ -899,6 +899,36 @@ def test_load_as_multiblock_non_loadable_file_before_loadable_file():
     assert isinstance(multi['HeadMRVolume'], pv.ImageData)
 
 
+@pytest.mark.parametrize(
+    ('filename', 'companion_names', 'reader_types'),
+    [
+        ('mesh.frd', ('pyvista_frd.FRDReader',), ()),
+        ('mesh.pv', ('pyvista_zstd.Reader',), ()),
+        ('mesh.zvtk', ('pyvista_zstd.Reader',), ()),
+        ('mesh.vtp', (), (pv.XMLPolyDataReader,)),
+        ('mesh.npy', (), ()),
+    ],
+)
+def test_unique_companion_reader_names(tmp_path, filename, companion_names, reader_types):
+    (path := tmp_path / filename).touch()
+    loader = _SingleFileDatasetLoader(str(path))
+    assert loader.unique_companion_reader_names == companion_names
+    assert loader.unique_reader_types == reader_types
+
+
+def test_unique_companion_reader_names_deduplicates(tmp_path):
+    paths = [tmp_path / 'mesh.pv', tmp_path / 'mesh.zvtk']
+    for path in paths:
+        path.touch()
+
+    def _files_func():
+        return tuple(_SingleFileDatasetLoader(str(path)) for path in paths)
+
+    loader = _MultiFileDatasetLoader(_files_func)
+    assert loader.unique_extensions == ('.pv', '.zvtk')
+    assert loader.unique_companion_reader_names == ('pyvista_zstd.Reader',)
+
+
 def test_overloads_register_with_typing_extensions():
     """Stubs must use `typing_extensions.overload` so `get_overloads` sees them on 3.10.
 


### PR DESCRIPTION
### Overview

The dataset gallery's `Reader` field comes from `unique_reader_types`, which is empty whenever `pv.get_reader` cannot resolve the file, so 13 cards read `N/A (generated in code)` right beside a file count, a size, an extension and a Data Source link. `.frd` is the clearest case: `pyvista-frd-reader` does read it, but registers a plain callable rather than a `BaseReader` subclass, so `get_reader` raises by design.

The field and its filter facet now have four states — a built-in reader, a companion package's reader, `N/A (read in code)` when the example function reads the files itself, and `N/A (generated in code)` only when there is no file. Companion readers render as literals since they have no page to link to, and they stay out of `Example.readers` and the generated reader overloads, both of which are typed to `BaseReader`.

`.pv` picks this up once #9148 lands.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
