### PR TITLE
Fix bugs found while annotating `core/utilities`

### DIFF
--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -28,8 +28,8 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
 
     Returns
     -------
-    str
-        The code URL. Empty string if there is no valid link.
+    str | None
+        The code URL. ``None`` if there is no valid link.
 
     Notes
     -----
@@ -83,10 +83,6 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
         fn = None
 
     if not fn:  # pragma: no cover
-        try:
-            fn = inspect.getsourcefile(sys.modules[obj.__module__])
-        except Exception:  # noqa: BLE001
-            return None
         return None
 
     fn = op.relpath(fn, start=op.dirname(pv.__file__))  # noqa: PTH120

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -488,11 +488,11 @@ def transform_vectors_sph_to_cart(*, theta, phi, r, u, v, w):  # numpydoc ignore
     r : array_like[float]
         Distance (radius) from the point of origin of shape ``(P,)``.
     u : array_like[float]
-        X-component of the vector of shape ``(P, N, M)``.
+        X-component of the vector of shape ``(M, N, P)`` with length-one axes dropped.
     v : array_like[float]
-        Y-component of the vector of shape ``(P, N, M)``.
+        Y-component of the vector of shape ``(M, N, P)`` with length-one axes dropped.
     w : array_like[float]
-        Z-component of the vector of shape ``(P, N, M)``.
+        Z-component of the vector of shape ``(M, N, P)`` with length-one axes dropped.
 
     Returns
     -------
@@ -652,10 +652,10 @@ def merge(
         msg = 'Expected at least one dataset.'
         raise ValueError(msg)
 
-    first = datasets[0]
-    if not isinstance(first, pv.DataSet):
-        msg = f'Expected pyvista.DataSet, not {type(first).__name__}'
-        raise TypeError(msg)
+    for i, dataset in enumerate(datasets):
+        if not isinstance(dataset, pv.DataSet):
+            msg = f'Expected pyvista.DataSet, not {type(dataset).__name__} at index {i}'
+            raise TypeError(msg)
 
     return datasets[0].merge(
         datasets[1:],

--- a/pyvista/core/utilities/image_sources.py
+++ b/pyvista/core/utilities/image_sources.py
@@ -296,7 +296,10 @@ class ImageNoiseSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageNoiseS
           The extent of the whole output image.
 
         """
-        return self._whole_extent
+        self.UpdateInformation()
+        return self.GetOutputInformation(0).Get(
+            _vtk.vtkStreamingDemandDrivenPipeline.WHOLE_EXTENT()
+        )
 
     @whole_extent.setter
     def whole_extent(self, whole_extent: Sequence[int]) -> None:
@@ -308,7 +311,6 @@ class ImageNoiseSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageNoiseS
           The extent of the whole output image.
 
         """
-        self._whole_extent = whole_extent
         self.SetWholeExtent(whole_extent)
 
     @property
@@ -400,7 +402,7 @@ class ImageSinusoidSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageSin
     period : float
         The period of the sinusoid in pixel.
 
-    phase : tuple
+    phase : float
         The phase of the sinusoid in pixel.
 
     amplitude : float
@@ -453,7 +455,10 @@ class ImageSinusoidSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageSin
             The extent of the whole output image.
 
         """
-        return self._whole_extent
+        self.UpdateInformation()
+        return self.GetOutputInformation(0).Get(
+            _vtk.vtkStreamingDemandDrivenPipeline.WHOLE_EXTENT()
+        )
 
     @whole_extent.setter
     def whole_extent(self, whole_extent: Sequence[int]) -> None:
@@ -465,7 +470,6 @@ class ImageSinusoidSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageSin
             The extent of the whole output image.
 
         """
-        self._whole_extent = whole_extent
         self.SetWholeExtent(
             whole_extent[0],
             whole_extent[1],
@@ -524,28 +528,28 @@ class ImageSinusoidSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageSin
         self.SetPeriod(period)
 
     @property
-    def phase(self) -> Sequence[float]:
+    def phase(self) -> float:
         """Get the phase of the sinusoid.
 
         Returns
         -------
-        sequence[float]
+        float
             The phase of the sinusoid in pixel.
 
         """
-        return self.GetPhase()  # type: ignore[return-value]
+        return self.GetPhase()
 
     @phase.setter
-    def phase(self, phase: Sequence[float]) -> None:
+    def phase(self, phase: float) -> None:
         """Set the phase of the sinusoid.
 
         Parameters
         ----------
-        phase : sequence[float]
+        phase : float
             The phase of the sinusoid in pixel.
 
         """
-        self.SetPhase(phase)  # type: ignore[arg-type]
+        self.SetPhase(phase)
 
     @property
     def amplitude(self) -> float:
@@ -601,7 +605,7 @@ class ImageGaussianSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGau
     maximum : float
         The maximum value of the Gaussian.
 
-    std : sequence[float]
+    std : float
         The standard deviation of the Gaussian.
 
     Examples
@@ -664,7 +668,10 @@ class ImageGaussianSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGau
           The extent of the whole output image.
 
         """
-        return self._whole_extent
+        self.UpdateInformation()
+        return self.GetOutputInformation(0).Get(
+            _vtk.vtkStreamingDemandDrivenPipeline.WHOLE_EXTENT()
+        )
 
     @whole_extent.setter
     def whole_extent(self, whole_extent: Sequence[int]) -> None:
@@ -676,7 +683,6 @@ class ImageGaussianSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGau
           The extent of the whole output image.
 
         """
-        self._whole_extent = whole_extent
         self.SetWholeExtent(
             whole_extent[0],
             whole_extent[1],
@@ -755,7 +761,7 @@ class ImageGridSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGridSou
 
     Parameters
     ----------
-    origin : sequence[float]
+    origin : sequence[int]
         The origin of the grid.
 
     extent : sequence[int]
@@ -787,28 +793,28 @@ class ImageGridSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGridSou
             self.spacing = spacing
 
     @property
-    def origin(self) -> Sequence[float]:
+    def origin(self) -> Sequence[int]:
         """Get the origin of the data.
 
         Returns
         -------
-        sequence[float]
+        sequence[int]
             The origin of the grid.
 
         """
         return self.GetGridOrigin()
 
     @origin.setter
-    def origin(self, origin: Sequence[float]) -> None:
+    def origin(self, origin: Sequence[int]) -> None:
         """Set the origin of the data.
 
         Parameters
         ----------
-        origin : sequence[float]
+        origin : sequence[int]
             The origin of the grid.
 
         """
-        self.SetGridOrigin(origin)  # type: ignore[arg-type]
+        self.SetGridOrigin(origin)
 
     @property
     def extent(self) -> Sequence[int]:

--- a/pyvista/core/utilities/image_sources.py
+++ b/pyvista/core/utilities/image_sources.py
@@ -762,7 +762,7 @@ class ImageGridSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGridSou
     Parameters
     ----------
     origin : sequence[int]
-        The origin of the grid.
+        The origin of the grid lines in pixels.
 
     extent : sequence[int]
         The extent of the whole output image, Default: (0,255,0,255,0,0).
@@ -794,24 +794,24 @@ class ImageGridSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkImageGridSou
 
     @property
     def origin(self) -> Sequence[int]:
-        """Get the origin of the data.
+        """Get the origin of the grid lines.
 
         Returns
         -------
         sequence[int]
-            The origin of the grid.
+            The origin of the grid lines in pixels.
 
         """
         return self.GetGridOrigin()
 
     @origin.setter
     def origin(self, origin: Sequence[int]) -> None:
-        """Set the origin of the data.
+        """Set the origin of the grid lines.
 
         Parameters
         ----------
         origin : sequence[int]
-            The origin of the grid.
+            The origin of the grid lines in pixels.
 
         """
         self.SetGridOrigin(origin)

--- a/pyvista/core/utilities/observers.py
+++ b/pyvista/core/utilities/observers.py
@@ -288,7 +288,7 @@ class Observer(_NoNewAttrMixin):
         else:
             logging.warning(alert)  # noqa: LOG015
 
-    def __call__(self, _obj, _event, message) -> None:
+    def __call__(self, _obj, _event, message='') -> None:
         """Declare standard call function for the observer.
 
         On an event occurrence, this function executes.
@@ -426,7 +426,8 @@ class ProgressMonitor(_NoNewAttrMixin):
         On an event occurrence, this function executes.
         """
         if self._interrupt_signal_received:
-            obj.AbortExecuteOn()
+            if (abort := getattr(obj, 'AbortExecuteOn', None)) is not None:
+                abort()
         else:
             progress = obj.GetProgress()
             step = progress - self._old_progress

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -190,6 +190,7 @@ class BaseVTKReader(ABC):
 
     def __init__(self: BaseVTKReader) -> None:
         self._data_object: pv.DataObject | None = None
+        self._filename: str | None = None
         self._observers: list[int | Callable[[Any], Any]] = []
 
     def SetFileName(self, filename) -> None:
@@ -395,6 +396,7 @@ class BaseReader(_FileIOBase, Generic[_T_Output_co]):
 
     @path.setter
     def path(self, path: str | Path):
+        path = str(path)
         if Path(path).is_dir():
             self._set_directory(path)
         elif Path(path).is_file():
@@ -1821,7 +1823,7 @@ class CGNSReader(BaseReader['MultiBlock'], PointCellDataSelection):
         return bool(self._reader.GetDistributeBlocks())
 
     @distribute_blocks.setter
-    def distribute_blocks(self, value: str) -> None:
+    def distribute_blocks(self, value: bool) -> None:
         self._reader.SetDistributeBlocks(value)
 
     def base_array_status(self, name: str) -> bool:
@@ -2877,7 +2879,7 @@ class _GRDECLReader(BaseVTKReader):
     def Update(self) -> None:
         """Read the GRDECL file and store internally to ``_data_object``."""
         self._data_object = _read_grdecl(
-            self._filename,
+            cast('str', self._filename),
             elevation=self._elevation,
             other_keywords=self._other_keywords,
         )
@@ -2975,7 +2977,7 @@ class _GIFReader(BaseVTKReader):
             micro=int(pillow_version.split('.')[2]),
         )
 
-        img = Image.open(self._filename)
+        img = Image.open(cast('str', self._filename))
         self._data_object = pv.ImageData(dimensions=(img.size[0], img.size[1], 1))
 
         # load each frame to the grid (RGB since gifs do not support transparency
@@ -3740,12 +3742,12 @@ class ExodusIIReader(BaseReader['MultiBlock'], PointCellDataSelection, TimeReade
 
     @property
     def number_cell_arrays(self):
-        """Return the number of point arrays.
+        """Return the number of cell arrays.
 
         Returns
         -------
         int
-            Number of point arrays.
+            Number of cell arrays.
 
         """
         return self.reader.GetNumberOfElementResultArrays()
@@ -3802,12 +3804,12 @@ class ExodusIIReader(BaseReader['MultiBlock'], PointCellDataSelection, TimeReade
 
     @property
     def number_global_arrays(self):
-        """Return the number of point arrays.
+        """Return the number of global arrays.
 
         Returns
         -------
         int
-            Number of point arrays.
+            Number of global arrays.
 
         """
         return self.reader.GetNumberOfGlobalResultArrays()
@@ -3822,7 +3824,7 @@ class ExodusIIReader(BaseReader['MultiBlock'], PointCellDataSelection, TimeReade
             List of all global array names.
 
         """
-        return [self.reader.GetGlobalResultArrayName(i) for i in range(self.number_cell_arrays)]
+        return [self.reader.GetGlobalResultArrayName(i) for i in range(self.number_global_arrays)]
 
     def enable_global_array(self, name):
         """Enable global array with name.
@@ -4258,7 +4260,7 @@ class ExodusIIBlockSet(_NoNewAttrMixin):
 
         """
         status_method = self._construct_result_method('Get', 'Status')
-        return status_method(name)
+        return bool(status_method(name))
 
 
 @dataclass(order=True)

--- a/tests/core/test_image_sources.py
+++ b/tests/core/test_image_sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 import pyvista as pv
 
@@ -162,3 +163,16 @@ def test_image_grid_source():
     assert source.extent == extent
     assert source.spacing == spacing
     assert isinstance(source.output, pv.ImageData)
+
+
+def test_image_grid_source_origin_shifts_grid_lines():
+    extent = (0, 9, 0, 9, 0, 0)
+    shifted = pv.ImageGridSource(origin=(2, 3, 0), extent=extent).output
+    unshifted = pv.ImageGridSource(origin=(0, 0, 0), extent=extent).output
+    assert not np.array_equal(shifted.active_scalars, unshifted.active_scalars)
+    assert shifted.origin == unshifted.origin
+
+
+def test_image_grid_source_origin_rejects_float():
+    with pytest.raises(TypeError, match='SetGridOrigin'):
+        pv.ImageGridSource(origin=(0.5, 0.5, 0.5))

--- a/tests/core/test_image_sources.py
+++ b/tests/core/test_image_sources.py
@@ -53,6 +53,8 @@ def test_image_noise_source():
     output_same_seed = pv.ImageNoiseSource(seed=0).output
     assert np.array_equal(output_same_seed.active_scalars, output_seed.active_scalars)
 
+    assert pv.ImageNoiseSource(whole_extent=None).whole_extent == (0, 255, 0, 255, 0, 0)
+
 
 def test_image_mandelbrot_source():
     whole_extent = (0, 20, 0, 20, 0, 0)
@@ -101,6 +103,8 @@ def test_image_gradient_source():
     assert source.std == std
     assert isinstance(source.output, pv.ImageData)
 
+    assert pv.ImageGaussianSource().whole_extent == (0, 255, 0, 255, 0, 0)
+
 
 def test_image_sinusolid_source():
     whole_extent = (0, 20, 0, 20, 0, 0)
@@ -136,6 +140,8 @@ def test_image_sinusolid_source():
     assert source.amplitude == amplitude
     assert source.direction == direction
     assert isinstance(source.output, pv.ImageData)
+
+    assert pv.ImageSinusoidSource().whole_extent == (0, 255, 0, 255, 0, 0)
 
 
 def test_image_grid_source():

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -19,6 +19,7 @@ from pyvista.core.utilities.fileio import _try_imageio_imread
 from pyvista.core.utilities.reader import _CLASS_READER_PATTERNS
 from pyvista.core.utilities.reader import _CLASS_READER_RETURN_TYPE
 from pyvista.core.utilities.reader import CLASS_READERS
+from pyvista.core.utilities.reader import _PVDReader
 from pyvista.examples.downloads import download_file
 
 if TYPE_CHECKING:
@@ -259,6 +260,24 @@ def test_reader_invalid_file():
     # cannot use the BaseReader
     with pytest.raises(FileNotFoundError, match='does not exist'):
         pv.DICOMReader('dummy/')
+
+
+def test_reader_path_setter_pathlib(tmpdir):
+    tmpfile = tmpdir.join('temp.vti')
+    pv.ImageData().save(tmpfile.strpath)
+
+    # file branch
+    reader = pv.get_reader(tmpfile.strpath)
+    reader.path = Path(tmpfile.strpath)
+    assert isinstance(reader.path, str)
+    assert reader.path == tmpfile.strpath
+
+    # directory branch
+    directory = examples.download_dicom_stack(load=False)
+    reader = pv.DICOMReader(directory)
+    reader.path = Path(directory)
+    assert isinstance(reader.path, str)
+    assert reader.path == directory
 
 
 def test_xmlimagedatareader(tmpdir):
@@ -776,6 +795,11 @@ def test_pvdreader_no_time_group():
         assert dataset.time == 0.0
         assert dataset.group is None
         assert dataset.part == i
+
+
+def test_pvdreader_no_filename():
+    with pytest.raises(ValueError, match='Filename must be set'):
+        _PVDReader().UpdateInformation()
 
 
 @pytest.mark.skip_windows
@@ -1809,6 +1833,22 @@ def test_exodus_reader_core():
         assert key in unstruct.cell_data.keys()
 
 
+def test_exodus_reader_global_arrays():
+    reader = pv.get_reader(examples.download_parallel_exodus(load=False))
+
+    expected_names = ['KE', 'XMOM', 'YMOM', 'ZMOM', 'NSTEPS', 'TMSTEP']
+    assert reader.number_global_arrays == len(expected_names)
+    assert reader.global_array_names == expected_names
+
+    reader.enable_all_global_arrays()
+    for name in expected_names:
+        assert reader.global_array_status(name)
+
+    reader.disable_all_global_arrays()
+    for name in expected_names:
+        assert not reader.global_array_status(name)
+
+
 def _test_block_names(block, names):
     assert block.number == len(names)
     assert block.names == names
@@ -1838,19 +1878,19 @@ def _test_block_arrays(block, array_names):
     block.enable_all_arrays()
 
     for array_name in array_names:
-        assert block.array_status(array_name)
+        assert block.array_status(array_name) is True
 
     block.disable_all_arrays()
     for array_name in array_names:
-        assert not block.array_status(array_name)
+        assert block.array_status(array_name) is False
 
     for array_name in array_names:
         block.enable_array(array_name)
-        assert block.array_status(array_name)
+        assert block.array_status(array_name) is True
 
     for array_name in array_names:
         block.disable_array(array_name)
-        assert not block.array_status(array_name)
+        assert block.array_status(array_name) is False
 
 
 def test_exodus_blocks():

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -761,6 +761,21 @@ def test_progress_monitor():
     assert isinstance(ugrid, pv.PolyData)
 
 
+def test_progress_monitor_interrupt_without_abort_execute():
+    from pyvista.core.utilities.reader import _PVDReader
+
+    algorithm = _vtk.vtkSphereSource()
+    monitor = ProgressMonitor(algorithm)
+    monitor._interrupt_signal_received = True
+    monitor(algorithm)
+    assert algorithm.GetAbortExecute()
+
+    reader = _PVDReader()
+    monitor = ProgressMonitor(reader)
+    monitor._interrupt_signal_received = True
+    monitor(reader)
+
+
 def test_observer():
     msg = 'KIND: In PATH, line 0\nfoo (0x000000): ALERT'
     obs = Observer()
@@ -803,6 +818,20 @@ def test_observer_default_event():
     assert ret.alert == msg
 
     assert str(ret) == msg
+
+
+def test_observer_called_without_message():
+    from pyvista.core.utilities.reader import _PVDReader
+
+    obs = Observer(event_type='ProgressEvent', log=False, store_history=True)
+    reader = _PVDReader()
+    reader.AddObserver(obs.event_type, obs)
+
+    reader.UpdateObservers(obs.event_type)
+
+    assert obs.has_event_occurred()
+    assert obs.get_message() == ''
+    assert obs.event_history[-1].alert == ''
 
 
 @pytest.mark.parametrize('point', [1, object(), None])
@@ -1064,6 +1093,9 @@ def test_merge(sphere, cube, datasets):
 
     with pytest.raises(TypeError, match=r'Expected pyvista.DataSet'):
         pv.merge([None, sphere])
+
+    with pytest.raises(TypeError, match=r'Expected pyvista.DataSet, not NoneType at index 1'):
+        pv.merge([sphere, None])
 
     # check polydata
     merged_poly = pv.merge([sphere, cube])


### PR DESCRIPTION
### Overview

Annotating `pyvista/core/utilities` surfaced a set of pre-existing defects. Each was reproduced at runtime before being fixed, and every behaviour change carries a test that fails without it. The annotations themselves are in two pull requests stacked on this one.

- `ExodusIIReader.global_array_names` iterated `number_cell_arrays`, so it truncated the list and `enable_all_global_arrays`/`disable_all_global_arrays` acted on the wrong set; `ExodusIIBlockSet.array_status` returned VTK's raw `int` where its docstring and eight sibling accessors promise `bool`.
- `BaseReader.path` returned a `PosixPath` when a `Path` was assigned, and `_PVDReader.UpdateInformation` raised `AttributeError` instead of its own `ValueError` because `BaseVTKReader` never initialised `_filename`.
- `Observer.__call__` required three arguments while `BaseVTKReader.UpdateObservers` dispatches two, and `ProgressMonitor.__call__` called `AbortExecuteOn` on readers that do not have it, so Ctrl-C during a progress-barred `.gif` or `.pvd` read crashed instead of deferring.
- `ImageNoiseSource`, `ImageSinusoidSource` and `ImageGaussianSource` raised `AttributeError` from `whole_extent` when the extent was never set, `pv.merge` validated only the first element of its sequence, and `linkcode_resolve` had a fallback that could never produce a link.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
