### PR TITLE
Correct render-pass composition and lifecycle

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -802,6 +802,7 @@ _OPENGL_MODULES: dict[str, tuple[str, ...]] = {
         'vtkCameraPass',
         'vtkCompositePolyDataMapper2',  # optional (contextlib.suppress)
         'vtkDepthOfFieldPass',
+        'vtkDualDepthPeelingPass',
         'vtkEDLShading',
         'vtkEGLRenderWindow',  # optional (Linux EGL builds)
         'vtkGaussianBlurPass',
@@ -818,6 +819,8 @@ _OPENGL_MODULES: dict[str, tuple[str, ...]] = {
         'vtkSSAOPass',
         'vtkShader',
         'vtkShadowMapPass',
+        'vtkToneMappingPass',
+        'vtkTranslucentPass',
         'vtkXOpenGLRenderWindow',  # optional (Linux X11 builds)
     ),
     'vtkRenderingVolumeOpenGL2': (

--- a/pyvista/plotting/render_passes.py
+++ b/pyvista/plotting/render_passes.py
@@ -11,6 +11,8 @@ from pyvista.core.utilities.misc import _NoNewAttrMixin
 
 # The order of both the pre and post-passes matters.
 PRE_PASS = [
+    # SSAO needs geometry positions and normals before image filtering.
+    'vtkSSAOPass',
     'vtkEDLShading',
 ]
 
@@ -18,13 +20,18 @@ POST_PASS = [
     'vtkDepthOfFieldPass',
     'vtkGaussianBlurPass',
     'vtkOpenGLFXAAPass',
-    'vtkSSAOPass',
-    'vtkSSAAPass',  # should be last
+    'vtkSSAAPass',
+    'vtkToneMappingPass',  # requires the renderer's final viewport size
 ]
 
 
 class RenderPasses(_NoNewAttrMixin):
     """Class to support multiple render passes for a renderer.
+
+    Parameters
+    ----------
+    renderer : :vtk:`vtkRenderer`
+        Renderer to initialize render passes for.
 
     Notes
     -----
@@ -36,10 +43,16 @@ class RenderPasses(_NoNewAttrMixin):
     are "stacked", while the post-processing passes are added as a final pass
     to the rendered image.
 
-    Parameters
-    ----------
-    renderer : :vtk:`vtkRenderer`
-        Renderer to initialize render passes for.
+    .. versionchanged:: 0.50
+        Preserve an externally installed base pipeline when composing or removing
+        managed effects. Image passes are ordered around its geometry stages;
+        tone mapping follows SSAA. Removing the last managed effect
+        restores the external pipeline and its original delegates.
+
+    External pipelines must not contain managed passes or cycles. External pass
+    objects remain owned by their caller. Native depth peeling and shadows are
+    composed into the translucent and opaque stages of a
+    :vtk:`vtkRenderStepsPass` base, respectively.
 
     """
 
@@ -49,6 +62,16 @@ class RenderPasses(_NoNewAttrMixin):
         self._closed = False
 
         self._passes = {}
+        self._base_pass = None
+        self._base_passes = []
+        self._base_links_installed = []
+        self._managed_active = False
+        self._installed_pass = None
+        self._render_steps_state = None
+        self._render_steps_installed = None
+        self._render_steps_camera = None
+        self._depth_peeling_pass = None
+        self._shadow_sequence = None
         self._fxaa_pass = None
         self._shadow_map_pass = None
         self._edl_pass = None
@@ -135,15 +158,31 @@ class RenderPasses(_NoNewAttrMixin):
 
     def deep_clean(self):
         """Delete all render passes."""
+        self._restore_render_steps()
+        self._release_depth_peeling()
         for render_pass in (
             *itertools.chain.from_iterable(self._passes.values()),
+            self._fxaa_pass,
             self._shadow_map_pass,
             self.__camera_pass,
         ):
             if render_pass is not None:
+                if hasattr(render_pass, 'SetDelegatePass'):
+                    render_pass.SetDelegatePass(None)
+                if render_pass is self._shadow_map_pass:
+                    render_pass.SetOpaqueSequence(None)
+                    render_pass.GetShadowMapBakerPass().SetOpaqueSequence(None)
                 self._release_graphics_resources(render_pass)
-        if self._renderer is not None:
-            self._renderer.SetPass(None)
+        self._restore_base_passes()
+        if self._renderer is not None and self._renderer.GetPass() is self._installed_pass:
+            self._renderer.SetPass(self._base_pass)
+        self._base_pass = None
+        self._base_passes = []
+        self._base_links_installed = []
+        self._managed_active = False
+        self._installed_pass = None
+        self._shadow_sequence = None
+        self._fxaa_pass = None
         self._renderer_ref = None  # type: ignore[assignment]
         if self.__seq_pass is not None:
             self.__seq_pass.SetPasses(None)
@@ -167,7 +206,10 @@ class RenderPasses(_NoNewAttrMixin):
             The enabled EDL pass.
 
         """
+        self._check_closed()
+        self._update_base_pass()
         if self._edl_pass is not None:
+            self._update_passes()
             return None
         self._edl_pass = _vtk.vtkEDLShading()
         self._add_pass(self._edl_pass)
@@ -192,6 +234,8 @@ class RenderPasses(_NoNewAttrMixin):
             The added Gaussian blur pass.
 
         """
+        self._check_closed()
+        self._update_base_pass()
         blur_pass = _vtk.vtkGaussianBlurPass()
         self._add_pass(blur_pass)
         self._blur_passes.append(blur_pass)
@@ -214,12 +258,18 @@ class RenderPasses(_NoNewAttrMixin):
 
         """
         self._check_closed()
-        # shadow pass can be directly added to the base pass collection
+        self._update_base_pass()
+        self._check_compatible('vtkShadowMapPass')
         if self._shadow_map_pass is not None:
+            self._update_passes()
             return None
+        if self._dof_pass is not None:
+            msg = 'Shadows are incompatible with the depth of field pass.'
+            raise RuntimeError(msg)
+        if not self._pass_collection.GetItemAsObject(0).IsA('vtkRenderStepsPass'):
+            msg = 'Shadows require a vtkRenderStepsPass geometry pipeline.'
+            raise RuntimeError(msg)
         self._shadow_map_pass = _vtk.vtkShadowMapPass()
-        self._pass_collection.AddItem(self._shadow_map_pass.GetShadowMapBakerPass())
-        self._pass_collection.AddItem(self._shadow_map_pass)
         self._update_passes()
         return self._shadow_map_pass
 
@@ -228,11 +278,13 @@ class RenderPasses(_NoNewAttrMixin):
         self._check_closed()
         if self._shadow_map_pass is None:
             return
-        self._release_graphics_resources(self._shadow_map_pass)
-        self._pass_collection.RemoveItem(self._shadow_map_pass.GetShadowMapBakerPass())
-        self._pass_collection.RemoveItem(self._shadow_map_pass)
+        shadow_pass = self._shadow_map_pass
         self._shadow_map_pass = None
         self._update_passes()
+        shadow_pass.SetOpaqueSequence(None)
+        shadow_pass.GetShadowMapBakerPass().SetOpaqueSequence(None)
+        self._release_graphics_resources(shadow_pass)
+        self._shadow_sequence = None
 
     @_deprecate_positional_args
     def enable_depth_of_field_pass(self, automatic_focal_distance: bool = True):  # noqa: FBT001, FBT002
@@ -250,8 +302,15 @@ class RenderPasses(_NoNewAttrMixin):
             The enabled depth of field pass.
 
         """
+        self._check_closed()
+        self._update_base_pass()
+        self._check_compatible('vtkDepthOfFieldPass')
         if self._dof_pass is not None:
+            self._update_passes()
             return None
+        if self._shadow_map_pass is not None:
+            msg = 'Depth of field is incompatible with shadows.'
+            raise RuntimeError(msg)
 
         if self._ssao_pass is not None:
             msg = 'Depth of field pass is incompatible with the SSAO pass.'
@@ -293,18 +352,24 @@ class RenderPasses(_NoNewAttrMixin):
             The enabled screen space ambient occlusion pass.
 
         """
+        self._check_closed()
+        self._update_base_pass()
         if self._dof_pass is not None:
             msg = 'SSAO pass is incompatible with the depth of field pass.'
             raise RuntimeError(msg)
 
-        if self._ssao_pass is not None:
-            return None
-        self._ssao_pass = _vtk.vtkSSAOPass()
+        self._check_compatible('vtkSSAOPass')
+        new_pass = self._ssao_pass is None
+        if new_pass:
+            self._ssao_pass = _vtk.vtkSSAOPass()
         self._ssao_pass.SetRadius(radius)
         self._ssao_pass.SetBias(bias)
         self._ssao_pass.SetKernelSize(kernel_size)
         self._ssao_pass.SetBlur(blur)
-        self._add_pass(self._ssao_pass)
+        if new_pass:
+            self._add_pass(self._ssao_pass)
+        else:
+            self._update_passes()
         return self._ssao_pass
 
     def disable_ssao_pass(self):
@@ -324,7 +389,10 @@ class RenderPasses(_NoNewAttrMixin):
             The enabled super-sample anti-aliasing pass.
 
         """
+        self._check_closed()
+        self._update_base_pass()
         if self._ssaa_pass is not None:
+            self._update_passes()
             return None
         self._ssaa_pass = _vtk.vtkSSAAPass()
         self._add_pass(self._ssaa_pass)
@@ -338,28 +406,403 @@ class RenderPasses(_NoNewAttrMixin):
         self._remove_pass(self._ssaa_pass)
         self._ssaa_pass = None
 
-    def _update_passes(self):
-        """Reassemble pass delegation."""
-        self._check_closed()
+    def _check_compatible(self, candidate=None):
+        """Reject incompatible depth-buffer consumers before changing the pipeline."""
+        external = self._validate_base_pass(self._base_pass, self._base_overrides())
+        names = {render_pass.GetClassName() for render_pass in external}
+        names.update(self._passes)
+        names.add(candidate)
+        if self._shadow_map_pass is not None:
+            names.add('vtkShadowMapPass')
+        if self._renderer.GetUseDepthPeeling():
+            names.add('vtkDualDepthPeelingPass')
+        if 'vtkDepthOfFieldPass' in names:
+            for name, label in (
+                ('vtkSSAOPass', 'the SSAO pass'),
+                ('vtkShadowMapPass', 'shadows'),
+                ('vtkDualDepthPeelingPass', 'depth peeling'),
+                ('vtkDepthPeelingPass', 'depth peeling'),
+            ):
+                if name in names:
+                    msg = f'Depth of field pass is incompatible with {label}.'
+                    raise RuntimeError(msg)
 
-        current_pass = self._camera_pass
-        for class_name in PRE_PASS + POST_PASS:
-            if class_name in self._passes:
-                for render_pass in self._passes[class_name]:
-                    render_pass.SetDelegatePass(current_pass)
-                    current_pass = render_pass
+    def _restore_render_steps(self):
+        """Restore opaque, translucent, and volume passes borrowed from the base."""
+        if self._render_steps_state is not None:
+            steps, *original = self._render_steps_state
+            for name, before, installed in zip(
+                ('OpaquePass', 'TranslucentPass', 'VolumetricPass'),
+                original,
+                self._render_steps_installed,
+                strict=True,
+            ):
+                if getattr(steps, 'Get' + name)() is installed:
+                    getattr(steps, 'Set' + name)(before)
+            self._restore_camera_cache()
+            self._render_steps_state = None
+            self._render_steps_installed = None
+            self._render_steps_camera = None
 
-        # reset to the default rendering if no special passes have been added
-        if current_pass is self._camera_pass and self._shadow_map_pass is None:
-            self._renderer.SetPass(None)
+    def _restore_camera_cache(self):
+        """Replace cached geometry stages when managed effects are removed."""
+        if self._render_steps_installed is not None:
+            steps = self._render_steps_state[0]
+            # VTK also retains the previous frame's stages in the camera's
+            # sequence. Restore only our substituted entries, so immediate
+            # toggles do not see disabled effects in that cache.
+            camera, sequence = self._render_steps_camera
+            if (
+                camera is not None
+                and camera.GetDelegatePass() is sequence
+                and sequence is not None
+                and sequence.IsA('vtkSequencePass')
+            ):
+                collection = sequence.GetPasses()
+                replacements = dict(
+                    zip(
+                        self._render_steps_installed,
+                        (
+                            steps.GetOpaquePass(),
+                            steps.GetTranslucentPass(),
+                            steps.GetVolumetricPass(),
+                        ),
+                        strict=True,
+                    )
+                )
+                if collection is not None:
+                    for index in reversed(range(collection.GetNumberOfItems())):
+                        item = collection.GetItemAsObject(index)
+                        if item in replacements and replacements[item] is not item:
+                            replacement = replacements[item]
+                            if replacement is None:
+                                collection.RemoveItem(index)
+                            else:
+                                collection.ReplaceItem(index, replacement)
+
+    def _release_depth_peeling(self):
+        """Release only the managed peeling pass, retaining its geometry delegates."""
+        if self._depth_peeling_pass is not None:
+            self._depth_peeling_pass.SetTranslucentPass(None)
+            self._depth_peeling_pass.SetVolumetricPass(None)
+            self._release_graphics_resources(self._depth_peeling_pass)
+            self._depth_peeling_pass = None
+
+    def _configure_render_steps(self):
+        """Apply shadows before translucent geometry and honor native peeling settings."""
+        steps = self._pass_collection.GetItemAsObject(0)
+        if not steps.IsA('vtkRenderStepsPass'):
+            return None
+        if self._render_steps_state is None:
+            camera = steps.GetCameraPass()
+            self._render_steps_camera = (
+                camera,
+                None if camera is None else camera.GetDelegatePass(),
+            )
+            self._render_steps_state = (
+                steps,
+                steps.GetOpaquePass(),
+                steps.GetTranslucentPass(),
+                steps.GetVolumetricPass(),
+            )
         else:
-            self._renderer.SetPass(current_pass)
+            overrides = self._base_overrides()
+            original = tuple(
+                overrides[steps, getter]
+                for getter in ('GetOpaquePass', 'GetTranslucentPass', 'GetVolumetricPass')
+            )
+            if original[0] is not self._render_steps_state[1]:
+                self._shadow_sequence = None
+            self._render_steps_state = (steps, *original)
+        _, opaque, translucent, volumetric = self._render_steps_state
+        if self._shadow_map_pass is not None:
+            if self._shadow_sequence is None:
+                opaque_passes = _vtk.vtkRenderPassCollection()
+                if steps.GetLightsPass() is not None:
+                    opaque_passes.AddItem(steps.GetLightsPass())
+                if opaque is not None:
+                    opaque_passes.AddItem(opaque)
+                opaque_sequence = _vtk.vtkSequencePass()
+                opaque_sequence.SetPasses(opaque_passes)
+                self._shadow_map_pass.SetOpaqueSequence(opaque_sequence)
+                baker = self._shadow_map_pass.GetShadowMapBakerPass()
+                light_camera = _vtk.vtkCameraPass()
+                light_camera.SetDelegatePass(opaque_sequence)
+                baker.SetOpaqueSequence(light_camera)
+                shadow_passes = _vtk.vtkRenderPassCollection()
+                shadow_passes.AddItem(baker)
+                shadow_passes.AddItem(self._shadow_map_pass)
+                self._shadow_sequence = _vtk.vtkSequencePass()
+                self._shadow_sequence.SetPasses(shadow_passes)
+            steps.SetOpaquePass(self._shadow_sequence)
+        else:
+            steps.SetOpaquePass(opaque)
+
+        if (
+            self._renderer.GetUseDepthPeeling()
+            and translucent is not None
+            and not (
+                translucent.IsA('vtkDepthPeelingPass')
+                or translucent.IsA('vtkDualDepthPeelingPass')
+            )
+        ):
+            if self._depth_peeling_pass is None:
+                self._depth_peeling_pass = _vtk.vtkDualDepthPeelingPass()
+            peeling = self._depth_peeling_pass
+            peeling.SetTranslucentPass(translucent)
+            peeling.SetMaximumNumberOfPeels(self._renderer.GetMaximumNumberOfPeels())
+            peeling.SetOcclusionRatio(self._renderer.GetOcclusionRatio())
+            if self._renderer.GetUseDepthPeelingForVolumes():
+                peeling.SetVolumetricPass(volumetric)
+                steps.SetVolumetricPass(None)
+            else:
+                peeling.SetVolumetricPass(None)
+                steps.SetVolumetricPass(volumetric)
+            steps.SetTranslucentPass(peeling)
+        else:
+            steps.SetTranslucentPass(translucent)
+            steps.SetVolumetricPass(volumetric)
+            self._release_depth_peeling()
+        # Peeling uses its own framebuffer attachments. SSAO's geometry buffers
+        # must be completed before that translucent stage changes the bindings.
+        staged_ssao = None
+        translucent = steps.GetTranslucentPass()
+        if (
+            self._passes.get('vtkSSAOPass')
+            and translucent is not None
+            and (
+                translucent.IsA('vtkDepthPeelingPass')
+                or translucent.IsA('vtkDualDepthPeelingPass')
+            )
+        ):
+            staged_ssao = self._passes['vtkSSAOPass'][0]
+            if steps.GetOpaquePass() is not None and (
+                self._render_steps_installed is None
+                or self._render_steps_installed[0] is not staged_ssao
+            ):
+                # Geometry cached for the previous framebuffer must be rebuilt
+                # for SSAO's multiple color attachments on this transition.
+                self._release_graphics_resources(steps.GetOpaquePass())
+            opaque_passes = _vtk.vtkRenderPassCollection()
+            if steps.GetLightsPass() is not None:
+                opaque_passes.AddItem(steps.GetLightsPass())
+            if steps.GetOpaquePass() is not None:
+                opaque_passes.AddItem(steps.GetOpaquePass())
+            opaque_sequence = _vtk.vtkSequencePass()
+            opaque_sequence.SetPasses(opaque_passes)
+            opaque_camera = _vtk.vtkCameraPass()
+            opaque_camera.SetDelegatePass(opaque_sequence)
+            staged_ssao.SetDelegatePass(opaque_camera)
+            steps.SetOpaquePass(staged_ssao)
+        self._restore_camera_cache()
+        self._render_steps_installed = (
+            steps.GetOpaquePass(),
+            steps.GetTranslucentPass(),
+            steps.GetVolumetricPass(),
+        )
+        return staged_ssao
+
+    def _base_overrides(self):
+        """Read caller-owned links without the stages temporarily inserted by this manager."""
+        overrides = {}
+        expected = dict(self._base_links_installed)
+        for render_pass, original in self._base_passes:
+            actual = render_pass.GetDelegatePass()
+            overrides[render_pass, 'GetDelegatePass'] = (
+                original if actual is expected.get(render_pass, original) else actual
+            )
+        if self._render_steps_state is not None:
+            steps, *original = self._render_steps_state
+            getters = ('GetOpaquePass', 'GetTranslucentPass', 'GetVolumetricPass')
+            for getter, before, installed in zip(
+                getters, original, self._render_steps_installed, strict=True
+            ):
+                actual = getattr(steps, getter)()
+                overrides[steps, getter] = before if actual is installed else actual
+        return overrides
+
+    def _validate_base_pass(self, root, overrides):
+        """Reject cycles and references back into the manager's active pipeline."""
+        managed = {
+            *itertools.chain.from_iterable(self._passes.values()),
+            self.__camera_pass,
+            self.__seq_pass,
+            self._fxaa_pass,
+            self._shadow_map_pass,
+            self._shadow_sequence,
+            self._depth_peeling_pass,
+        }
+        visited = set()
+        active = set()
+
+        def visit(render_pass, *, camera_cache=False):
+            """Validate each delegate and each pass in a composite pipeline.
+
+            Parameters
+            ----------
+            render_pass : :vtk:`vtkRenderPass`
+                Pass to visit.
+            camera_cache : bool, default: False
+                Whether the pass belongs to the cached render-steps sequence.
+
+            """
+            if render_pass is None:
+                return
+            # RenderStepsPass caches its geometry stages beneath its camera.
+            # Those cached references are replaced by VTK at the next render.
+            cached_ssao = (
+                self._render_steps_installed is not None
+                and self._render_steps_installed[0] is self._ssao_pass
+                and render_pass is self._ssao_pass
+            )
+            if camera_cache and (
+                cached_ssao or render_pass in (self._shadow_sequence, self._depth_peeling_pass)
+            ):
+                return
+            if render_pass in active or render_pass in managed:
+                msg = 'An external base pipeline cannot contain cycles or managed render passes.'
+                raise ValueError(msg)
+            if render_pass in visited:
+                return
+            active.add(render_pass)
+            for getter in (
+                'GetDelegatePass',
+                'GetCameraPass',
+                'GetOpaqueSequence',
+                'GetShadowMapBakerPass',
+                'GetLightsPass',
+                'GetOpaquePass',
+                'GetTranslucentPass',
+                'GetVolumetricPass',
+                'GetOverlayPass',
+                'GetPostProcessPass',
+            ):
+                if hasattr(render_pass, getter):
+                    child = overrides.get((render_pass, getter), getattr(render_pass, getter)())
+                    cached_camera = (
+                        getter == 'GetCameraPass'
+                        and self._render_steps_camera is not None
+                        and child is self._render_steps_camera[0]
+                        and child is not None
+                        and child.GetDelegatePass() is self._render_steps_camera[1]
+                    )
+                    visit(child, camera_cache=camera_cache or cached_camera)
+            if hasattr(render_pass, 'GetPasses'):
+                collection = render_pass.GetPasses()
+                if collection is not None:
+                    for index in range(collection.GetNumberOfItems()):
+                        visit(collection.GetItemAsObject(index), camera_cache=camera_cache)
+            active.remove(render_pass)
+            visited.add(render_pass)
+
+        visit(root)
+        return visited
+
+    def _restore_base_passes(self):
+        """Restore borrowed links while retaining changes made by the caller."""
+        for (render_pass, getter), delegate in self._base_overrides().items():
+            if getter == 'GetDelegatePass':
+                render_pass.SetDelegatePass(delegate)
+        self._base_links_installed = []
+
+    def _update_base_pass(self):
+        """Capture the caller's pipeline, including edits beneath an unchanged root."""
+        current = self._renderer.GetPass()
+        links_changed = any(
+            render_pass.GetDelegatePass() is not delegate
+            for render_pass, delegate in self._base_links_installed
+        )
+        if self._managed_active and current is self._installed_pass and not links_changed:
+            self._validate_base_pass(self._base_pass, self._base_overrides())
+            return
+        if not self._managed_active and current is None and self._base_pass is None:
+            return
+        if self._managed_active and current is self._installed_pass:
+            current = self._base_pass
+        overrides = self._base_overrides()
+        self._validate_base_pass(current, overrides)
+        links = []
+        delegate = current
+        while delegate is not None and (
+            delegate.IsA('vtkImageProcessingPass') or delegate.IsA('vtkSSAAPass')
+        ):
+            next_pass = overrides.get((delegate, 'GetDelegatePass'), delegate.GetDelegatePass())
+            links.append((delegate, next_pass))
+            delegate = next_pass
+        self._restore_render_steps()
+        self._restore_base_passes()
+        self._base_pass = current
+        self._base_passes = links
+        self._shadow_sequence = None
+        self._pass_collection.ReplaceItem(0, delegate or _vtk.vtkRenderStepsPass())
+
+    def _update_passes(self):
+        """Reassemble geometry and image passes while retaining an external base pipeline."""
+        self._check_closed()
+        self._update_base_pass()
+        self._check_compatible()
+        passes = {name: list(items) for name, items in self._passes.items()}
+        for render_pass, _ in reversed(self._base_passes):
+            passes.setdefault(render_pass.GetClassName(), []).append(render_pass)
+
+        # Native FXAA is bypassed when VTK renders through a custom pass.
+        if (
+            not passes.get('vtkOpenGLFXAAPass')
+            and self._renderer.GetUseFXAA()
+            and (self._passes or self._shadow_map_pass is not None or self._base_pass is not None)
+        ):
+            if self._fxaa_pass is None:
+                self._fxaa_pass = _vtk.vtkOpenGLFXAAPass()
+            self._fxaa_pass.SetFXAAOptions(self._renderer.GetFXAAOptions())
+            passes.setdefault('vtkOpenGLFXAAPass', []).append(self._fxaa_pass)
+        elif self._fxaa_pass is not None:
+            self._fxaa_pass.SetDelegatePass(None)
+            self._release_graphics_resources(self._fxaa_pass)
+            self._fxaa_pass = None
+
+        native_peeling = self._base_pass is not None and self._renderer.GetUseDepthPeeling()
+        if (
+            not self._passes
+            and self._shadow_map_pass is None
+            and self._fxaa_pass is None
+            and not native_peeling
+        ):
+            self._restore_render_steps()
+            self._release_depth_peeling()
+            self._restore_base_passes()
+            self._renderer.SetPass(self._base_pass)
+            self._installed_pass = self._base_pass
+            self._managed_active = False
+            return
+
+        staged_ssao = self._configure_render_steps()
+        current_pass = (
+            self._pass_collection.GetItemAsObject(0)
+            if staged_ssao is not None
+            else self._camera_pass
+        )
+        # Unknown external image passes retain their order outside managed effects.
+        order = (
+            PRE_PASS + POST_PASS + [name for name in passes if name not in PRE_PASS + POST_PASS]
+        )
+        for class_name in order:
+            for render_pass in passes.get(class_name, []):
+                if render_pass is staged_ssao:
+                    continue
+                render_pass.SetDelegatePass(current_pass)
+                current_pass = render_pass
+        self._renderer.SetPass(current_pass)
+        self._installed_pass = current_pass
+        self._managed_active = True
+        self._base_links_installed = [
+            (render_pass, render_pass.GetDelegatePass()) for render_pass, _ in self._base_passes
+        ]
 
     def _add_pass(self, render_pass):
         """Add a render pass."""
         class_name = render_pass.GetClassName()
 
-        if class_name in PRE_PASS and render_pass in self._passes:
+        if render_pass in self._passes.get(class_name, []):
             return
 
         if class_name not in self._passes:
@@ -374,6 +817,7 @@ class RenderPasses(_NoNewAttrMixin):
         renderer = self._renderer
         ren_win = None if renderer is None else renderer.GetRenderWindow()
         if ren_win is not None:
+            ren_win.MakeCurrent()
             render_pass.ReleaseGraphicsResources(ren_win)
 
     def _remove_pass(self, render_pass):
@@ -387,6 +831,7 @@ class RenderPasses(_NoNewAttrMixin):
         if class_name not in self._passes:  # pragma: no cover
             return
         else:
+            render_pass.SetDelegatePass(None)
             self._release_graphics_resources(render_pass)
             self._passes[class_name].remove(render_pass)
             if not self._passes[class_name]:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -49,7 +49,6 @@ from .tools import create_axes_orientation_box
 from .tools import create_north_arrow
 from .tools import parse_font_family
 from .utilities.gl_checks import check_depth_peeling
-from .utilities.gl_checks import uses_egl
 
 if TYPE_CHECKING:
     from pyvista.core._typing_core import RotationLike
@@ -767,6 +766,10 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
     def enable_depth_peeling(self, number_of_peels=None, occlusion_ratio=None):
         """Enable depth peeling to improve rendering of translucent geometry.
 
+        .. versionchanged:: 0.50
+            Retain depth peeling when image passes are enabled. Combining depth
+            peeling with depth of field raises an error.
+
         Parameters
         ----------
         number_of_peels : int, optional
@@ -789,6 +792,9 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             If depth peeling is supported.
 
         """
+        self._render_passes._check_closed()
+        self._render_passes._update_base_pass()
+        self._render_passes._check_compatible('vtkDualDepthPeelingPass')
         if number_of_peels is None:
             number_of_peels = self._theme.depth_peeling.number_of_peels
         if occlusion_ratio is None:
@@ -798,16 +804,24 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             self.SetUseDepthPeeling(True)
             self.SetMaximumNumberOfPeels(number_of_peels)
             self.SetOcclusionRatio(occlusion_ratio)
+            self._render_passes._update_passes()
         self.Modified()
         return depth_peeling_supported
 
     def disable_depth_peeling(self) -> None:
         """Disable depth peeling."""
+        self._render_passes._check_closed()
+        self._render_passes._update_base_pass()
         self.SetUseDepthPeeling(False)
+        self._render_passes._update_passes()
         self.Modified()
 
     def enable_anti_aliasing(self, aa_type='ssaa'):
         """Enable anti-aliasing.
+
+        .. versionchanged:: 0.50
+            Compose FXAA with active image passes, including on EGL windows.
+            Selecting FXAA does not substitute SSAA.
 
         Parameters
         ----------
@@ -821,18 +835,11 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         aa_type = aa_type.lower()
 
         if aa_type == 'fxaa':
-            if uses_egl():  # pragma: no cover
-                # only display the warning when not building documentation
-                if not pv.BUILDING_GALLERY:
-                    warn_external(
-                        'VTK compiled with OSMesa/EGL does not properly support '
-                        'FXAA anti-aliasing and SSAA will be used instead.',
-                    )
-                self._render_passes.enable_ssaa_pass()
-                return
+            self._render_passes.disable_ssaa_pass()
             self._enable_fxaa()
 
         elif aa_type == 'ssaa':
+            self._disable_fxaa()
             self._render_passes.enable_ssaa_pass()
 
         else:
@@ -842,17 +849,22 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
     def disable_anti_aliasing(self) -> None:
         """Disable all anti-aliasing."""
         self._render_passes.disable_ssaa_pass()
-        self.SetUseFXAA(False)
-        self.Modified()
+        self._disable_fxaa()
 
     def _enable_fxaa(self) -> None:
         """Enable FXAA anti-aliasing."""
+        self._render_passes._check_closed()
+        self._render_passes._update_base_pass()
         self.SetUseFXAA(True)
+        self._render_passes._update_passes()
         self.Modified()
 
     def _disable_fxaa(self) -> None:
         """Disable FXAA anti-aliasing."""
+        self._render_passes._check_closed()
+        self._render_passes._update_base_pass()
         self.SetUseFXAA(False)
+        self._render_passes._update_passes()
         self.Modified()
 
     def add_border(self, color='white', width=1.0, edges=None):
@@ -3465,6 +3477,11 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
     def enable_depth_of_field(self, automatic_focal_distance=True) -> None:  # noqa: FBT002
         """Enable depth of field plotting.
 
+        .. versionchanged:: 0.50
+            Raise an error when combined with shadows or depth peeling, including
+            externally installed passes. These combinations cannot provide the
+            depth buffer required by this effect.
+
         Parameters
         ----------
         automatic_focal_distance : bool, default: True
@@ -3549,6 +3566,11 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
     def enable_shadows(self) -> None:
         """Enable shadows.
 
+        .. versionchanged:: 0.50
+            Render shadows before translucent geometry. Combining shadows with
+            depth of field raises an error. An external geometry pipeline must
+            use :vtk:`vtkRenderStepsPass` to expose its opaque stage.
+
         Examples
         --------
         First, plot without shadows enabled (default)
@@ -3624,6 +3646,15 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         blur : bool, default: True
             Controls if occlusion buffer should be blurred before combining it
             with the color buffer.
+
+        Notes
+        -----
+        Calling this method again updates the settings of the existing SSAO pass.
+        With depth peeling enabled, SSAO processes opaque geometry before
+        translucent geometry is composited.
+
+        .. versionchanged:: 0.50
+            Repeated calls update the SSAO settings.
 
         Examples
         --------

--- a/tests/plotting/test_render_pass.py
+++ b/tests/plotting/test_render_pass.py
@@ -97,8 +97,10 @@ def test_shadow_pass():
     ren_pass = passes.enable_shadow_pass()
     assert isinstance(ren_pass, _vtk.vtkShadowMapPass)
 
-    assert passes._pass_collection.IsItemPresent(ren_pass)
-    assert passes._pass_collection.IsItemPresent(ren_pass.GetShadowMapBakerPass())
+    steps = passes._pass_collection.GetItemAsObject(0)
+    opaque = steps.GetOpaquePass().GetPasses()
+    assert opaque.GetItemAsObject(0) is ren_pass.GetShadowMapBakerPass()
+    assert opaque.GetItemAsObject(1) is ren_pass
     assert ren.GetPass() is not None
 
     passes.disable_shadow_pass()
@@ -111,8 +113,9 @@ def test_shadow_pass():
     new_pass = passes.enable_shadow_pass()
     assert isinstance(new_pass, _vtk.vtkShadowMapPass)
     assert new_pass is not ren_pass
-    assert passes._pass_collection.IsItemPresent(new_pass)
-    assert passes._pass_collection.IsItemPresent(new_pass.GetShadowMapBakerPass())
+    opaque = steps.GetOpaquePass().GetPasses()
+    assert opaque.GetItemAsObject(0) is new_pass.GetShadowMapBakerPass()
+    assert opaque.GetItemAsObject(1) is new_pass
 
 
 def test_edl_pass():
@@ -142,9 +145,17 @@ def test_ssao_pass():
     assert isinstance(ren_pass, _vtk.vtkSSAOPass)
     assert list(passes._passes.keys()).count('vtkSSAOPass') == 1
 
-    # enabling again should just not add the pass again
-    ren_pass = passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=16, blur=False)
+    updated_pass = passes.enable_ssao_pass(radius=2.0, bias=0.02, kernel_size=64, blur=True)
+    assert updated_pass is ren_pass
+    assert ren_pass.GetRadius() == 2.0
+    assert ren_pass.GetBias() == 0.02
+    assert ren_pass.GetKernelSize() == 64
+    assert ren_pass.GetBlur()
     assert list(passes._passes.keys()).count('vtkSSAOPass') == 1
+
+    modification_time = ren_pass.GetMTime()
+    passes.enable_ssao_pass(radius=2.0, bias=0.02, kernel_size=64, blur=True)
+    assert ren_pass.GetMTime() == modification_time
 
     passes.disable_ssao_pass()
     assert not passes._passes
@@ -154,12 +165,12 @@ def test_ssao_pass():
     assert not passes._passes
 
 
-def test_render_passes_deep_clean():
+@pytest.mark.parametrize('effect', ['enable_depth_of_field_pass', 'enable_shadow_pass'])
+def test_render_passes_deep_clean(effect):
     ren, passes = make_passes()
     passes.add_blur_pass()
-    passes.enable_depth_of_field_pass()
+    getattr(passes, effect)()
     passes.enable_edl_pass()
-    passes.enable_shadow_pass()
     passes.enable_ssaa_pass()
 
     passes.deep_clean()
@@ -206,3 +217,222 @@ def test_render_pass_releases_graphics_resources(enable, disable):
         getattr(pl, disable)()
         pl.close()
     assert catcher.error_events == []
+
+
+def test_ssao_pass_closed():
+    """A closed renderer rejects SSAO before allocating a pass."""
+    _ren, passes = make_passes()
+    passes.close()
+    with pytest.raises(RuntimeError, match='closed'):
+        passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    assert passes._ssao_pass is None
+    assert not passes._passes
+
+
+@pytest.mark.parametrize('image_pass', [None, 'vtkToneMappingPass', 'vtkSSAAPass'])
+def test_external_base_restore(image_pass):
+    """A custom translucent pipeline survives managed effects and their removal."""
+    ren, passes = make_passes()
+    steps = _vtk.vtkRenderStepsPass()
+    peeling = _vtk.vtkDualDepthPeelingPass()
+    translucent = _vtk.vtkTranslucentPass()
+    peeling.SetTranslucentPass(translucent)
+    steps.SetTranslucentPass(peeling)
+    base = steps if image_pass is None else getattr(_vtk, image_pass)()
+    if base is not steps:
+        base.SetDelegatePass(steps)
+    ren.SetPass(base)
+    passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    assert passes._pass_collection.GetItemAsObject(0) is steps
+    assert steps.GetTranslucentPass() is peeling
+    assert peeling.GetTranslucentPass() is translucent
+    passes.disable_ssao_pass()
+    assert ren.GetPass() is base
+    if base is not steps:
+        assert base.GetDelegatePass() is steps
+    passes.enable_edl_pass()
+    passes.deep_clean()
+    assert ren.GetPass() is base
+    assert steps.GetTranslucentPass() is peeling
+
+
+def test_external_base_replacement():
+    """Replacing or clearing a base between toggles never resurrects the old base."""
+    ren, passes = make_passes()
+    first = _vtk.vtkRenderStepsPass()
+    second = _vtk.vtkRenderStepsPass()
+    ren.SetPass(first)
+    passes.enable_ssaa_pass()
+    ren.SetPass(second)
+    passes.add_blur_pass()
+    assert passes._pass_collection.GetItemAsObject(0) is second
+    passes.remove_blur_pass()
+    passes.disable_ssaa_pass()
+    assert ren.GetPass() is second
+    ren.SetPass(None)
+    passes.enable_ssaa_pass()
+    passes.disable_ssaa_pass()
+    assert ren.GetPass() is None
+
+
+def test_external_delegate_edit():
+    """An edit beneath an unchanged external root is retained on disable."""
+    ren, passes = make_passes()
+    tone = _vtk.vtkToneMappingPass()
+    first = _vtk.vtkRenderStepsPass()
+    second = _vtk.vtkRenderStepsPass()
+    tone.SetDelegatePass(first)
+    ren.SetPass(tone)
+    passes.enable_ssaa_pass()
+    assert ren.GetPass() is tone
+    tone.SetDelegatePass(second)
+    passes.add_blur_pass()
+    assert passes._pass_collection.GetItemAsObject(0) is second
+    passes.remove_blur_pass()
+    passes.disable_ssaa_pass()
+    assert ren.GetPass() is tone
+    assert tone.GetDelegatePass() is second
+
+
+@pytest.mark.parametrize('wrapper', ['vtkCameraPass', 'vtkGaussianBlurPass'])
+def test_external_managed_cycle_rejected(wrapper):
+    """Wrapping an active managed graph fails before allocating another pass."""
+    ren, passes = make_passes()
+    active = passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    external = getattr(_vtk, wrapper)()
+    external.SetDelegatePass(active)
+    ren.SetPass(external)
+    with pytest.raises(ValueError, match='cycles or managed render passes'):
+        passes.add_blur_pass()
+    assert not passes._blur_passes
+    assert list(passes._passes) == ['vtkSSAOPass']
+    assert ren.GetPass() is external
+    external.SetDelegatePass(None)
+    ren.SetPass(active)
+    passes.deep_clean()
+
+
+@pytest.mark.parametrize('first', ['dof', 'shadows', 'peeling'])
+def test_depth_of_field_incompatible_passes(first):
+    """Reject unsupported depth-buffer combinations in either enable order."""
+    ren, passes = make_passes()
+    if first == 'dof':
+        passes.enable_depth_of_field_pass()
+        with pytest.raises(RuntimeError, match='incompatible'):
+            passes.enable_shadow_pass()
+        assert passes._shadow_map_pass is None
+    else:
+        if first == 'shadows':
+            passes.enable_shadow_pass()
+        else:
+            ren.SetUseDepthPeeling(True)
+        with pytest.raises(RuntimeError, match='incompatible'):
+            passes.enable_depth_of_field_pass()
+        assert passes._dof_pass is None
+
+
+def test_render_steps_edits_preserved():
+    """Restoring borrowed geometry stages preserves caller changes."""
+    ren, passes = make_passes()
+    steps = _vtk.vtkRenderStepsPass()
+    ren.SetPass(steps)
+    passes.enable_shadow_pass()
+    translucent = _vtk.vtkTranslucentPass()
+    steps.SetTranslucentPass(translucent)
+    passes.disable_shadow_pass()
+    assert steps.GetTranslucentPass() is translucent
+    assert ren.GetPass() is steps
+
+
+@pytest.mark.parametrize('slot', ['OpaquePass', 'CameraPass'])
+def test_external_render_steps_cycle_rejected(slot):
+    """Edits to borrowed geometry or camera stages cannot introduce managed cycles."""
+    ren, passes = make_passes()
+    steps = _vtk.vtkRenderStepsPass()
+    original = getattr(steps, 'Get' + slot)()
+    ren.SetPass(steps)
+    active = passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    getattr(steps, 'Set' + slot)(active if slot == 'OpaquePass' else passes._camera_pass)
+    with pytest.raises(ValueError, match='cycles or managed render passes'):
+        passes.add_blur_pass()
+    assert not passes._blur_passes
+    getattr(steps, 'Set' + slot)(original)
+    passes.deep_clean()
+
+
+def test_reenable_after_external_replacement():
+    """Re-enabling SSAO reconnects it to a newly installed external base."""
+    ren, passes = make_passes()
+    active = passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    steps = _vtk.vtkRenderStepsPass()
+    ren.SetPass(steps)
+    passes.enable_ssao_pass(radius=0.8, bias=0.005, kernel_size=256, blur=True)
+    assert ren.GetPass() is active
+    assert passes._pass_collection.GetItemAsObject(0) is steps
+    passes.disable_ssao_pass()
+    assert ren.GetPass() is steps
+
+
+def test_external_same_class_order():
+    """Distinct tone-mapping operations retain their original relative order."""
+    ren, passes = make_passes()
+    outer = _vtk.vtkToneMappingPass()
+    inner = _vtk.vtkToneMappingPass()
+    steps = _vtk.vtkRenderStepsPass()
+    outer.SetDelegatePass(inner)
+    inner.SetDelegatePass(steps)
+    ren.SetPass(outer)
+    passes.enable_ssaa_pass()
+    assert ren.GetPass() is outer
+    assert outer.GetDelegatePass() is inner
+    assert inner.GetDelegatePass() is passes._ssaa_pass
+    passes.disable_ssaa_pass()
+    assert outer.GetDelegatePass() is inner
+    assert inner.GetDelegatePass() is steps
+
+
+def test_external_fxaa_not_duplicated():
+    """The caller's FXAA pass satisfies the renderer's FXAA flag."""
+    ren, passes = make_passes()
+    fxaa = _vtk.vtkOpenGLFXAAPass()
+    fxaa.SetDelegatePass(_vtk.vtkRenderStepsPass())
+    ren.SetPass(fxaa)
+    ren.SetUseFXAA(True)
+    passes.enable_ssao_pass(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+    assert passes._fxaa_pass is None
+    assert ren.GetPass() is fxaa
+    assert fxaa.GetDelegatePass() is passes._ssao_pass
+    passes.disable_ssao_pass()
+    assert ren.GetPass() is fxaa
+
+
+@pytest.mark.parametrize('enable', ['enable_shadow_pass', 'enable_ssao_pass'])
+def test_external_depth_of_field_rejected(enable):
+    """The incompatibility checks include externally installed image passes."""
+    ren, passes = make_passes()
+    dof = _vtk.vtkDepthOfFieldPass()
+    dof.SetDelegatePass(_vtk.vtkRenderStepsPass())
+    ren.SetPass(dof)
+    kwargs = (
+        dict(radius=0.5, bias=0.005, kernel_size=256, blur=True)
+        if enable == 'enable_ssao_pass'
+        else {}
+    )
+    with pytest.raises(RuntimeError, match='incompatible'):
+        getattr(passes, enable)(**kwargs)
+    assert not passes._passes
+    assert ren.GetPass() is dof
+
+
+def test_release_uses_owning_context(mocker):
+    """Removing a pass activates its live window before freeing GPU resources."""
+    pl = pv.Plotter()
+    pl.enable_ssao()
+    render_pass = pl.renderer._render_passes._ssao_pass
+    calls = []
+    mocker.patch.object(pl.ren_win, 'MakeCurrent', side_effect=lambda: calls.append('current'))
+    mocker.patch.object(render_pass, 'ReleaseGraphicsResources', side_effect=calls.append)
+    pl.disable_ssao()
+    assert calls == ['current', pl.ren_win]
+    assert render_pass.GetDelegatePass() is None
+    pl.close()

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -1225,3 +1225,288 @@ def test_init_renderers_shape_descriptor_positive_raises(shape):
     match = f'"shape" must contain only positive integers. Got {shape!r}.'
     with pytest.raises(ValueError, match=re.escape(match)):
         pv.Plotter(shape=shape)
+
+
+def test_ssao_settings_update():
+    """Repeated calls update the active pass and retain the API defaults."""
+    pl = pv.Plotter()
+    pl.enable_ssao()
+    ssao = pl.renderer._render_passes._ssao_pass
+    assert ssao.GetRadius() == 0.5
+    assert ssao.GetBias() == 0.005
+    assert ssao.GetKernelSize() == 256
+    assert ssao.GetBlur()
+    pl.enable_ssao(radius=2.5, bias=0.03, blur=False)
+    assert pl.renderer._render_passes._ssao_pass is ssao
+    assert ssao.GetRadius() == 2.5
+    assert ssao.GetBias() == 0.03
+    assert ssao.GetKernelSize() == 256
+    assert not ssao.GetBlur()
+    pl.close()
+
+
+@pytest.mark.parametrize('effect', ['blur', 'edl', 'ssaa'])
+@pytest.mark.parametrize('ssao_first', [False, True])
+def test_ssao_with_image_passes(effect, ssao_first):
+    """Image filters retain SSAO's geometry buffers regardless of call order."""
+    pl = pv.Plotter(window_size=(300, 300))
+    mesh = pv.ImageData(dimensions=(3, 2, 2)).to_tetrahedra(12).explode()
+    pl.add_mesh(mesh, color='white', smooth_shading=False)
+    if ssao_first:
+        pl.enable_ssao()
+    if effect == 'blur':
+        pl.add_blurring()
+    elif effect == 'edl':
+        pl.enable_eye_dome_lighting()
+    else:
+        pl.enable_anti_aliasing(effect)
+    if not ssao_first:
+        pl.enable_ssao()
+    passes = pl.renderer._render_passes
+    assert passes._ssao_pass.GetDelegatePass() is passes._camera_pass
+    pl.camera_position = 'iso'
+    pl.show(auto_close=False)
+    with_ssao = pl.screenshot().astype(float)
+    pl.disable_ssao()
+    pl.render()
+    without_ssao = pl.screenshot().astype(float)
+    assert np.abs(with_ssao - without_ssao).mean() > 1.0
+    pl.close()
+
+
+@pytest.mark.parametrize('external', [False, True])
+def test_depth_peeling_with_image_pass(external):
+    """Translucent geometry is actually rendered through the peeling pass."""
+    pl = pv.Plotter(window_size=(300, 300))
+    pl.ren_win.SetMultiSamples(0)
+    pl.add_mesh(pv.Cube(), color='red', opacity=0.4)
+    pl.add_mesh(pv.Sphere(center=(0.4, 0.1, 0.3)), color='blue', opacity=0.5)
+    if external:
+        steps = pv._vtk.vtkRenderStepsPass()
+        peeling = pv._vtk.vtkDualDepthPeelingPass()
+        peeling.SetTranslucentPass(pv._vtk.vtkTranslucentPass())
+        steps.SetTranslucentPass(peeling)
+        pl.renderer.SetPass(steps)
+    else:
+        assert pl.enable_depth_peeling()
+    pl.enable_ssao()
+    pl.camera_position = 'iso'
+    pl.show(auto_close=False)
+    if not external:
+        peeling = pl.renderer._render_passes._depth_peeling_pass
+    assert peeling.GetNumberOfRenderedProps() == 2
+    pl.disable_ssao()
+    if external:
+        assert pl.renderer.GetPass() is steps
+        assert steps.GetTranslucentPass() is peeling
+    else:
+        assert pl.renderer.GetPass() is None
+        assert pl.renderer.GetUseDepthPeeling()
+    pl.close()
+
+
+@pytest.mark.parametrize('fxaa_first', [False, True])
+def test_fxaa_with_custom_pass(fxaa_first):
+    """FXAA affects edge pixels while retaining the requested AA algorithm."""
+    pl = pv.Plotter(window_size=(300, 300))
+    pl.background_color = 'black'
+    pl.add_mesh(pv.Cube().rotate_z(23), color='white', lighting=False)
+    if fxaa_first:
+        pl.enable_anti_aliasing('fxaa')
+    pl.enable_ssao(radius=0.0)
+    pl.camera_position = 'iso'
+    pl.show(auto_close=False)
+    pl.renderer._disable_fxaa()
+    pl.render()
+    before = pl.screenshot().astype(float)
+    pl.enable_anti_aliasing('fxaa')
+    pl.render()
+    after = pl.screenshot().astype(float)
+    passes = pl.renderer._render_passes
+    assert passes._ssaa_pass is None
+    assert passes._fxaa_pass.GetFXAAOptions() is pl.renderer.GetFXAAOptions()
+    assert np.count_nonzero(np.any(before != after, axis=2)) > 100
+    assert np.any((after[:, :, 0] > 0) & (after[:, :, 0] < 255))
+    pl.disable_ssao()
+    assert pl.renderer.GetPass() is None
+    assert pl.renderer.GetUseFXAA()
+    pl.close()
+
+
+def test_tone_mapping_with_ssaa():
+    """Tone mapping processes the full final viewport when combined with SSAA."""
+    pl = pv.Plotter(window_size=(300, 240))
+    pl.background_color = 'white'
+    pl.add_mesh(pv.Cube().rotate_z(23), color='tomato')
+    steps = pv._vtk.vtkRenderStepsPass()
+    tone = pv._vtk.vtkToneMappingPass()
+    tone.SetDelegatePass(steps)
+    pl.renderer.SetPass(tone)
+    pl.enable_anti_aliasing('ssaa')
+    pl.show(auto_close=False)
+    image = pl.screenshot()
+    assert (image[0] > 100).all()
+    assert (image[-1] > 100).all()
+    assert (image[:, 0] > 100).all()
+    assert (image[:, -1] > 100).all()
+    pl.disable_anti_aliasing()
+    assert pl.renderer.GetPass() is tone
+    assert tone.GetDelegatePass() is steps
+    pl.close()
+
+
+@pytest.mark.parametrize('samples', [0, 8])
+def test_msaa_depth_capture(samples):
+    """A tilted plane bounds depth error to less than a pixel's depth variation."""
+    pl = pv.Plotter(window_size=(137, 103))
+    pl.add_mesh(pv.Plane(direction=(0.2, 0.3, 1), i_size=12, j_size=12))
+    pl.camera_position = [(0, 0, 10), (0, 0, 0), (0, 1, 0)]
+    pl.camera.parallel_projection = True
+    pl.camera.parallel_scale = 2
+    pl.enable_anti_aliasing('msaa', multi_samples=samples)
+    pl.show(auto_close=False)
+    active_samples = pl.ren_win.GetMultiSamples()
+    depth = pl.get_image_depth(reset_camera_clipping_range=False)
+    y, x = np.indices(depth.shape)
+    expected = -10 - 0.2 * ((x + 0.5 - 137 / 2) * 4 / 103)
+    expected -= 0.3 * ((103 / 2 - y - 0.5) * 4 / 103)
+    assert np.isfinite(depth).all()
+    # Multisampling selects a covered subpixel, rather than the pixel center.
+    np.testing.assert_allclose(depth, expected, atol=(0.2 + 0.3) * 4 / 103)
+    near, far = pl.camera.clipping_range
+    center = -(pl.renderer.GetZ(68, 51) * (far - near) + near)
+    assert abs(center + 10) < (0.2 + 0.3) * 4 / 103
+    assert pl.ren_win.GetMultiSamples() == active_samples
+    assert (active_samples > 0) == (samples > 0)
+    pl.close()
+
+
+def test_depth_peeling_rejects_depth_of_field():
+    """An unsupported combination fails without enabling native peeling."""
+    pl = pv.Plotter()
+    pl.enable_depth_of_field()
+    with pytest.raises(RuntimeError, match='incompatible'):
+        pl.enable_depth_peeling()
+    assert not pl.renderer.GetUseDepthPeeling()
+    pl.close()
+
+
+def test_shadows_reenable_with_translucency():
+    """Shadows return after toggling and retain translucent geometry in front."""
+    pl = pv.Plotter(window_size=(320, 240), lighting=None)
+    pl.background_color = 'white'
+    pl.add_mesh(pv.Plane(i_size=6, j_size=6), color='white')
+    pl.add_mesh(pv.Cube(center=(0, 0, 0.6)), color='tomato')
+    sphere = pl.add_mesh(pv.Sphere(center=(1, -1, 1)), color='blue', opacity=0.5)
+    pl.add_light(
+        pv.Light(position=(-3, -4, 6), focal_point=(0, 0, 0), positional=True, cone_angle=50)
+    )
+    pl.camera_position = [(5, -7, 6), (0, 0, 0.2), (0, 0, 1)]
+    pl.enable_shadows()
+    pl.show(auto_close=False)
+    first = pl.screenshot().astype(float)
+    # The receiver must remain illuminated outside the cast shadow.
+    gray = first[:, :, 0]
+    lit_receiver = (gray > 100) & (gray < 250) & (first[:, :, 0] == first[:, :, 1])
+    assert np.count_nonzero(lit_receiver) > 100
+    sphere.visibility = False
+    pl.render()
+    without_translucency = pl.screenshot().astype(float)
+    assert np.abs(first - without_translucency).mean() > 0.5
+    sphere.visibility = True
+    pl.disable_shadows()
+    pl.render()
+    without_shadows = pl.screenshot().astype(float)
+    assert np.abs(first - without_shadows).mean() > 1.0
+    pl.enable_shadows()
+    pl.render()
+    restored = pl.screenshot().astype(float)
+    np.testing.assert_allclose(first, restored, atol=1)
+    pl.close()
+
+
+@pytest.mark.parametrize('keep_blur', [False, True])
+def test_external_shadow_toggle_does_not_retain_cached_shadow(keep_blur):
+    """Switching from shadows to DOF does not require an intermediate render."""
+    pl = pv.Plotter()
+    pl.add_mesh(pv.Cube())
+    steps = pv._vtk.vtkRenderStepsPass()
+    pl.renderer.SetPass(steps)
+    if keep_blur:
+        pl.add_blurring()
+    pl.enable_shadows()
+    pl.show(auto_close=False)
+    pl.disable_shadows()
+    pl.enable_depth_of_field()
+    assert pl.renderer._render_passes._dof_pass is not None
+    pl.disable_depth_of_field()
+    if keep_blur:
+        pl.remove_blurring()
+    assert pl.renderer.GetPass() is steps
+    pl.close()
+
+
+def test_native_depth_peeling_with_external_base_after_toggle():
+    """Native peeling stays active on an external base when SSAO is removed."""
+    pl = pv.Plotter()
+    pl.ren_win.SetMultiSamples(0)
+    pl.add_mesh(pv.Cube(), opacity=0.4)
+    steps = pv._vtk.vtkRenderStepsPass()
+    original = steps.GetTranslucentPass()
+    pl.renderer.SetPass(steps)
+    assert pl.enable_depth_peeling()
+    pl.enable_ssao()
+    pl.show(auto_close=False)
+    pl.disable_ssao()
+    pl.render()
+    peeling = steps.GetTranslucentPass()
+    assert peeling.IsA('vtkDualDepthPeelingPass')
+    assert peeling.GetNumberOfRenderedProps() == 1
+    pl.disable_depth_peeling()
+    assert steps.GetTranslucentPass() is original
+    assert pl.renderer.GetPass() is steps
+    pl.close()
+
+
+@pytest.mark.parametrize('external', [False, True])
+@pytest.mark.parametrize('ssao_first', [False, True])
+def test_ssao_depth_peeling_preserves_colors(external, ssao_first):
+    """Peeling retains material colors while SSAO darkens opaque contacts."""
+    pl = pv.Plotter(window_size=(320, 240), lighting=None)
+    pl.add_light(pv.Light(light_type='headlight'))
+    pl.background_color = 'white'
+    pl.ren_win.SetMultiSamples(0)
+    pl.add_mesh(pv.Cube(center=(0, 0, 0.5)), color='white', smooth_shading=False)
+    pl.add_mesh(pv.Plane(i_size=4, j_size=4), color='white')
+    pl.add_mesh(pv.Sphere(center=(1, -0.5, 1)), color='blue', opacity=0.4)
+    pl.camera_position = [(5, -7, 6), (0, 0, 0.2), (0, 0, 1)]
+    if ssao_first:
+        pl.enable_ssao()
+        pl.show(auto_close=False)
+    if external:
+        steps = pv._vtk.vtkRenderStepsPass()
+        peeling = pv._vtk.vtkDualDepthPeelingPass()
+        peeling.SetTranslucentPass(pv._vtk.vtkTranslucentPass())
+        steps.SetTranslucentPass(peeling)
+        pl.renderer.SetPass(steps)
+    else:
+        assert pl.enable_depth_peeling()
+    if not ssao_first:
+        # Exercise geometry already cached for a non-SSAO framebuffer.
+        pl.show(auto_close=False)
+    for _ in range(2):
+        pl.enable_ssao()
+        pl.render()
+        enabled = pl.screenshot().astype(float)
+        # White geometry and blue transparency cannot produce red/green hues.
+        np.testing.assert_allclose(enabled[:, :, 0], enabled[:, :, 1], atol=1)
+        assert np.all(enabled[:, :, 2] >= enabled[:, :, 0] - 1)
+        assert np.count_nonzero(enabled[:, :, 2] > enabled[:, :, 0] + 20) > 100
+        pl.disable_ssao()
+        pl.render()
+        disabled = pl.screenshot().astype(float)
+        assert np.abs(enabled - disabled).mean() > 0.2
+        if external:
+            assert pl.renderer.GetPass() is steps
+            assert steps.GetTranslucentPass() is peeling
+    pl.close()


### PR DESCRIPTION
### Overview

Preserve external render pipelines through effect toggles and correct composition of SSAO, depth peeling, shadows, FXAA, and tone mapping. Related to #8685 and [Bane Sullivan’s comment](https://github.com/pyvista/pyvista/issues/8685#issuecomment-4474547352); this does not close the issue.

Parked at the author’s request. This draft is not ready to merge: shadow artifacts and SSAO/opacity artifacts remain unresolved. Keep compatibility with unmodified VTK wheels, existing SSAO defaults and 256 samples, full-resolution AO, unchanged geometry/flat normals, and MSAA. The HTML comparison-report generator is preserved in the parking note on this draft.

🤖 Generated with [Codex](https://openai.com/codex/)
