### PR TITLE
Document installing cvista instead of stock VTK

### DIFF
--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -194,6 +194,54 @@ That installs the fork alongside stock ``vtk``; because it imports under its own
 ``cvista`` name, it does not clobber an existing install. When it is present
 PyVista selects it automatically.
 
+The fork does not replace stock VTK -- ``vtk`` remains a hard requirement of
+PyVista, so both are installed. To install the fork *instead of* stock VTK,
+drop the requirement during resolution. This needs `uv <https://docs.astral.sh/uv/>`_;
+pip has no equivalent.
+
+For a project, declare it once and it is recorded in the lock file:
+
+.. code-block:: toml
+
+    [project]
+    dependencies = ['pyvista[cvista]']
+
+    [tool.uv]
+    exclude-dependencies = ['vtk']
+
+For a one-off install:
+
+.. tab-set::
+
+    .. tab-item:: bash / zsh
+
+        .. code-block:: bash
+
+            uv pip install --excludes <(echo vtk) 'pyvista[cvista]'
+
+    .. tab-item:: PowerShell
+
+        .. code-block:: powershell
+
+            'vtk' | Out-File -Encoding ascii no-vtk.txt
+            uv pip install --excludes no-vtk.txt 'pyvista[cvista]'
+
+    .. tab-item:: Any shell
+
+        .. code-block:: text
+
+            uv pip install --excludes no-vtk.txt 'pyvista[cvista]'
+
+.. note::
+
+   The resulting environment is functionally correct but reports as
+   inconsistent, since PyVista's metadata still requires ``vtk``::
+
+       $ uv pip check
+       Found 4 incompatibilities
+       The package `pyvista` requires `vtk>=9.3.1`, but it's not installed
+       ...
+
 Set :envvar:`PYVISTA_VTK_BACKEND` to choose explicitly. It must be set **before**
 PyVista is imported, since the backend is resolved at import time::
 

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -230,6 +230,7 @@ For a one-off install:
 
         .. code-block:: text
 
+            echo vtk > no-vtk.txt
             uv pip install --excludes no-vtk.txt 'pyvista[cvista]'
 
 .. note::

--- a/doc/styles/config/vocabularies/pyvista/accept.txt
+++ b/doc/styles/config/vocabularies/pyvista/accept.txt
@@ -470,6 +470,7 @@ unticked
 untrusted
 upscaling
 url
+uv
 validators
 vendoring
 venv


### PR DESCRIPTION
Resolves #9213

`vtk` is an unconditional core requirement, so `pyvista[cvista]` installs both — an extra can only add. The **VTK Backend** section already says as much but offers no way out; this documents uv's `--excludes` / `exclude-dependencies`, which drops a name from the resolution outright.

| macOS arm64 | |
| --- | --- |
| stock `vtk` 9.7.0 | 103 MB |
| `cvista` + rendering + io | 36.5 MB |

- Project form (`[tool.uv] exclude-dependencies`), a bash/zsh one-liner, and a file-based form for PowerShell and `sh`, which have no process substitution.
- A note that `uv pip check` then reports 4 incompatibilities permanently — unavoidable short of splitting the distribution.
- `uv` added to the Vale vocabulary.

Open: whether this wants its own subheading, and that it is the first place the docs reach for uv over pip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
