### PR TITLE
Accept `'none'` as no culling in `add_actor`

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1119,11 +1119,14 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         name : str, optional
             Name to assign to the actor.  Defaults to the memory address.
 
-        culling : str, default: False
-            Does not render faces that are culled. Options are
-            ``'front'`` or ``'back'``. This can be helpful for dense
-            surface meshes, especially when edges are visible, but can
-            cause flat meshes to be partially displayed.
+        culling : str | bool, default: False
+            Does not render faces that are culled. This can be helpful for
+            dense surface meshes, especially when edges are visible, but can
+            cause flat meshes to be partially displayed. One of the following:
+
+            * ``True``, ``'b'``, ``'back'``, ``'backface'`` - Enable backface culling
+            * ``'f'``, ``'front'``, ``'frontface'`` - Enable frontface culling
+            * ``False``, ``'none'`` - Leave culling as the actor already has it
 
         pickable : bool, default: True
             Whether to allow this actor to be pickable within the
@@ -1177,7 +1180,7 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         if isinstance(culling, str):
             culling = culling.lower()
 
-        if culling:
+        if culling and culling != 'none':
             if culling in [True, 'back', 'backface', 'b']:
                 with contextlib.suppress(AttributeError):
                     actor.GetProperty().BackfaceCullingOn()
@@ -2313,9 +2316,10 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             Default is ``True``. when ``False``, a box with faces is
             shown with the specified culling.
 
-        culling : str, default: "front"
-            Does not render faces on the bounding box that are culled. Options
-            are ``'front'`` or ``'back'``.
+        culling : str | bool, default: "front"
+            Does not render faces on the bounding box that are culled. Takes
+            the same values as :meth:`add_actor`, such as ``'front'``,
+            ``'back'`` or ``'none'``.
 
         Returns
         -------

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -1155,6 +1155,44 @@ def test_add_actor_raises():
         pl.renderer.add_actor(_vtk.vtkActor(), culling='foo')
 
 
+@pytest.mark.parametrize(
+    ('culling', 'expected'),
+    [
+        ('none', (False, False)),
+        (False, (False, False)),
+        ('back', (True, False)),
+        ('backface', (True, False)),
+        ('b', (True, False)),
+        (True, (True, False)),
+        ('front', (False, True)),
+        ('frontface', (False, True)),
+        ('f', (False, True)),
+        ('NoNe', (False, False)),
+    ],
+)
+def test_add_actor_culling(culling, expected):
+    pl = pv.Plotter()
+    _, prop = pl.renderer.add_actor(_vtk.vtkActor(), culling=culling)
+    assert (bool(prop.GetBackfaceCulling()), bool(prop.GetFrontfaceCulling())) == expected
+    pl.close()
+
+
+def test_add_actor_culling_accepts_property_getter(sphere):
+    # `Property.culling` reports 'none' when disabled, so it must round trip
+    pl = pv.Plotter()
+    actor = pl.add_mesh(sphere)
+    assert actor.prop.culling == 'none'
+    pl.renderer.add_actor(_vtk.vtkActor(), culling=actor.prop.culling)
+    pl.close()
+
+
+def test_add_bounding_box_culling_none(sphere):
+    pl = pv.Plotter()
+    pl.add_mesh(sphere)
+    pl.add_bounding_box(culling='none')
+    pl.close()
+
+
 @pytest.mark.parametrize('grid', [1.0, 1, object()])
 def test_show_bounds_grid_raises(grid):
     pl = pv.Plotter()


### PR DESCRIPTION
`Property.culling` reports `'none'` when culling is disabled, but `Renderer.add_actor` read `'none'` as a truthy unknown option and raised `Culling option (none) not understood`, so the getter's own value could not be fed back to it. `add_bounding_box` and `add_volume` both route their `culling` through `add_actor`, so they raised too. `'none'` now means what `False` already meant there: leave the actor's culling alone.

The `add_actor` docstring listed only `'front'` and `'back'`, which undersold the aliases and bools it has always taken, so it now lists them all.

- `add_actor(culling=actor.prop.culling)` round trips for every value the getter returns.
- `False` stays a no-op rather than clearing culling, since `add_mesh` sets culling on the property and then calls `add_actor` with the default.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
