### PR TITLE
Exclude string arrays from cell-to-point conversion

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -122,6 +122,7 @@ _CORE_MODULES: dict[str, tuple[str, ...]] = {
         'VTK_DOUBLE_MAX',
         'VTK_DOUBLE_MIN',
         'VTK_FONT_FILE',
+        'VTK_STRING',
         'VTK_TIMES',
         'VTK_UNSIGNED_CHAR',
         'buffer_shared',

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -5263,6 +5263,10 @@ class DataObjectFilters:
         Point data are specified per node and cell data specified within cells.
         Optionally, the input point data can be passed through to the output.
 
+        .. versionchanged:: 0.50
+            String arrays are excluded from conversion with a warning. They remain
+            in the input and are passed through when ``pass_point_data=True``.
+
         Parameters
         ----------
         pass_point_data : bool, default: False
@@ -5289,6 +5293,11 @@ class DataObjectFilters:
         output : DataSet | MultiBlock
             Dataset with the point data transformed into cell data.
             Return type matches input.
+
+        Raises
+        ------
+        ValueError
+            If point arrays are unnamed and string arrays are present.
 
         See Also
         --------
@@ -5335,12 +5344,61 @@ class DataObjectFilters:
 
         alg = _vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(self)
+        point_data = self.point_data.VTKObject
+        # Inspect native types without copying string values into NumPy.
+        strings = [
+            i
+            for i in range(point_data.GetNumberOfArrays())
+            if point_data.GetAbstractArray(i).GetDataType() == _vtk.VTK_STRING
+        ]
+        if strings:
+            if any(not point_data.GetArrayName(i) for i in range(point_data.GetNumberOfArrays())):
+                msg = 'Name all point arrays before converting data with string arrays.'
+                raise ValueError(msg)
+            for i in strings:
+                name = point_data.GetAbstractArray(i).GetName()
+                warn_external(f'Dropping string array {name!r} from point-to-cell conversion.')
+            if categorical:
+                # VTK's selective mode loses the scalars required for categorization.
+                mesh = self.copy(deep=False)
+                for i in reversed(strings):
+                    mesh.point_data.VTKObject.RemoveArray(i)
+                alg.SetInputDataObject(mesh)
+            else:
+                alg.ProcessAllArraysOff()
+                for i in range(point_data.GetNumberOfArrays()):
+                    if i not in strings:
+                        name = point_data.GetAbstractArray(i).GetName()
+                        alg.AddPointDataArray(name)
+                # Selection loses attribute roles, including their interpolation policy.
+                cell_data = alg.GetOutput().GetCellData()
+                for role in range(_vtk.vtkDataSetAttributes.NUM_ATTRIBUTES):
+                    attribute = point_data.GetAbstractAttribute(role)
+                    if attribute is not None and not cell_data.GetCopyAttribute(
+                        role, _vtk.vtkDataSetAttributes.INTERPOLATE
+                    ):
+                        alg.RemovePointDataArray(attribute.GetName())
         alg.SetPassPointData(pass_point_data)
         alg.SetCategoricalData(categorical)
         _update_alg(
             alg, progress_bar=progress_bar, message='Transforming point data into cell data'
         )
-        return _get_output(alg, active_scalars=self.active_scalars_name)
+        output = _get_output(alg, active_scalars=self.active_scalars_name)
+        if strings and categorical and pass_point_data:
+            output.point_data.VTKObject.PassData(point_data)
+        if not alg.GetProcessAllArrays():
+            # VTK's array selection retains values but loses the active roles.
+            for role in range(_vtk.vtkDataSetAttributes.NUM_ATTRIBUTES):
+                attribute = self.point_data.VTKObject.GetAttribute(role)
+                if (
+                    attribute is not None
+                    and attribute.GetName() in output.cell_data
+                    and output.cell_data.VTKObject.GetCopyAttribute(
+                        role, _vtk.vtkDataSetAttributes.INTERPOLATE
+                    )
+                ):
+                    output.cell_data.VTKObject.SetActiveAttribute(attribute.GetName(), role)
+        return output
 
     def ptc(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1622,6 +1622,157 @@ def test_point_data_to_cell_data():
     _ = data.ptc()
 
 
+@pytest.mark.parametrize('pass_point_data', [False, True])
+@pytest.mark.parametrize('categorical', [False, True])
+@pytest.mark.parametrize('dtype', ['U', 'S'])
+@pytest.mark.parametrize('unstructured', [False, True])
+def test_point_data_to_cell_data_strings(pass_point_data, categorical, dtype, unstructured):
+    mesh = pv.ImageData(dimensions=(2, 2, 2))
+    if unstructured:
+        mesh = mesh.cast_to_unstructured_grid()
+    mesh.point_data['values'] = np.array([0, 0, 0, 0, 1, 2, 3, 4], dtype=float)
+    mesh.point_data['labels'] = np.arange(mesh.n_points).astype(dtype)
+    mesh.point_data['names'] = np.full(mesh.n_points, 'name', dtype=dtype)
+    mesh.cell_data['existing'] = [42]
+    mesh.field_data['description'] = ['metadata']
+    original = mesh.copy()
+
+    with pytest.warns(UserWarning, match='Dropping string array') as caught:
+        result = mesh.point_data_to_cell_data(
+            pass_point_data=pass_point_data, categorical=categorical
+        )
+
+    assert len(caught) == 2
+    assert "'labels'" in str(caught[0].message)
+    assert "'names'" in str(caught[1].message)
+    assert result.cell_data.keys() == ['existing', 'values']
+    assert result.cell_data['values'][0] == (0 if categorical else 1.25)
+    assert result.cell_data['existing'][0] == 42
+    assert result.field_data == original.field_data
+    assert result.point_data.keys() == (original.point_data.keys() if pass_point_data else [])
+    if pass_point_data:
+        assert result.point_data == original.point_data
+        assert np.shares_memory(result.point_data['values'], mesh.point_data['values'])
+    assert mesh == original
+
+
+@pytest.mark.parametrize('categorical', [False, True])
+def test_point_data_to_cell_data_strings_no_copies(monkeypatch, categorical):
+    mesh = pv.ImageData(dimensions=(2, 2, 2)).cast_to_unstructured_grid()
+    mesh.point_data['values'] = np.array([0, 0, 0, 0, 1, 2, 3, 4], dtype=float)
+    mesh.point_data['labels'] = np.arange(mesh.n_points).astype(str)
+    original_copy = pv.DataObject.copy
+    copies = []
+
+    def check_copy(self, deep=True):
+        assert categorical
+        assert deep is False
+        copied = original_copy(self, deep=deep)
+        copies.append(copied)
+        return copied
+
+    def forbid_copy(*_args, **_kwargs):
+        pytest.fail('Conversion must not copy the input or materialize string values.')
+
+    with monkeypatch.context() as patch:
+        patch.setattr(pv.DataObject, 'copy', check_copy)
+        patch.setattr(pv.core.utilities.arrays, 'convert_string_array', forbid_copy)
+        with pytest.warns(UserWarning, match="Dropping string array 'labels'"):
+            result = mesh.point_data_to_cell_data(pass_point_data=True, categorical=categorical)
+
+    assert len(copies) == int(categorical)
+    for copied in copies:
+        assert np.shares_memory(copied.points, mesh.points)
+        assert np.shares_memory(copied.point_data['values'], mesh.point_data['values'])
+    assert np.shares_memory(result.points, mesh.points)
+    assert np.shares_memory(result.point_data['values'], mesh.point_data['values'])
+    assert result.cell_data['values'][0] == (0 if categorical else 1.25)
+
+
+@pytest.mark.parametrize('categorical', [False, True])
+@pytest.mark.parametrize('unnamed_string', [False, True])
+@pytest.mark.parametrize('name', [None, ''])
+def test_point_data_to_cell_data_unnamed_arrays(categorical, unnamed_string, name):
+    mesh = pv.ImageData(dimensions=(2, 2, 2))
+    mesh.point_data['values'] = np.arange(mesh.n_points, dtype=float)
+    mesh.point_data['labels'] = np.arange(mesh.n_points).astype(str)
+    index = int(unnamed_string)
+    unnamed = mesh.point_data.VTKObject.GetAbstractArray(index)
+    unnamed.SetName(name)
+    with pytest.raises(ValueError, match='Name all point arrays'):
+        mesh.point_data_to_cell_data(categorical=categorical)
+    assert unnamed.GetName() == name
+    assert mesh.point_data.VTKObject.GetNumberOfArrays() == 2
+
+
+@pytest.mark.parametrize('role', ['GLOBALIDS', 'PEDIGREEIDS', 'PROCESSIDS'])
+def test_point_data_to_cell_data_attribute_exclusions(role):
+    mesh = pv.ImageData(dimensions=(2, 2, 2))
+    mesh.point_data['values'] = np.arange(mesh.n_points, dtype=float)
+    mesh.point_data['ids'] = np.arange(mesh.n_points)
+    mesh.cell_data['ids'] = [42]
+    mesh.point_data.VTKObject.SetActiveAttribute('ids', getattr(_vtk.vtkDataSetAttributes, role))
+    expected = mesh.point_data_to_cell_data()
+    assert expected.cell_data['ids'][0] == 42
+    mesh.point_data['labels'] = np.arange(mesh.n_points).astype(str)
+    with pytest.warns(UserWarning, match="Dropping string array 'labels'"):
+        result = mesh.point_data_to_cell_data()
+    assert result == expected
+    assert (
+        result.cell_data.VTKObject.GetAbstractAttribute(getattr(_vtk.vtkDataSetAttributes, role))
+        is None
+    )
+
+
+@pytest.mark.parametrize('with_strings', [False, True])
+@pytest.mark.parametrize(
+    'role', ['active_vectors_name', 'active_normals_name', 'active_texture_coordinates_name']
+)
+def test_point_data_to_cell_data_active_roles(with_strings, role):
+    mesh = pv.Sphere(phi_resolution=8, theta_resolution=8)
+    mesh.point_data['values'] = np.arange(mesh.n_points, dtype=float)
+    mesh.point_data['vectors'] = mesh.points
+    mesh.point_data['texture'] = mesh.points[:, :2]
+    mesh.point_data.active_vectors_name = 'vectors'
+    mesh.point_data.active_texture_coordinates_name = 'texture'
+    expected = getattr(mesh.point_data, role)
+    assert expected is not None
+    if with_strings:
+        mesh.point_data['labels'] = np.arange(mesh.n_points).astype(str)
+        with pytest.warns(UserWarning, match="Dropping string array 'labels'"):
+            result = mesh.point_data_to_cell_data()
+    else:
+        result = mesh.point_data_to_cell_data()
+    assert getattr(result.cell_data, role) == expected
+    assert getattr(mesh.point_data, role) == expected
+
+
+@pytest.mark.parametrize('pass_point_data', [False, True])
+def test_point_data_to_cell_data_only_strings(pass_point_data):
+    mesh = pv.ImageData(dimensions=(2, 2, 2))
+    mesh.point_data['labels'] = np.arange(mesh.n_points).astype(str)
+    with pytest.warns(UserWarning, match="Dropping string array 'labels'"):
+        result = mesh.ptc(pass_point_data=pass_point_data)
+    assert not result.cell_data
+    assert result.point_data.keys() == (['labels'] if pass_point_data else [])
+    assert mesh.point_data.keys() == ['labels']
+
+
+def test_point_data_to_cell_data_strings_composite():
+    numeric = pv.ImageData(dimensions=(2, 2, 2))
+    numeric.point_data['values'] = np.arange(numeric.n_points, dtype=float)
+    strings = numeric.copy()
+    strings.point_data['values'] = np.arange(strings.n_points).astype(str)
+    mesh = pv.MultiBlock({'numeric': numeric, 'nested': pv.MultiBlock([strings, None])})
+    original = mesh.copy()
+    with pytest.warns(UserWarning, match="Dropping string array 'values'"):
+        result = mesh.point_data_to_cell_data()
+    assert result['numeric'].cell_data['values'][0] == 3.5
+    assert not result['nested'][0].cell_data
+    assert result['nested'][1] is None
+    assert mesh == original
+
+
 def test_point_data_to_cell_data_composite(multiblock_all_no_pointset):
     # Now test composite data structures
     output = multiblock_all_no_pointset.point_data_to_cell_data(progress_bar=True)

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1642,9 +1642,10 @@ def test_point_data_to_cell_data_strings(pass_point_data, categorical, dtype, un
             pass_point_data=pass_point_data, categorical=categorical
         )
 
-    assert len(caught) == 2
-    assert "'labels'" in str(caught[0].message)
-    assert "'names'" in str(caught[1].message)
+    assert [str(w.message) for w in caught if issubclass(w.category, UserWarning)] == [
+        "Dropping string array 'labels' from point-to-cell conversion.",
+        "Dropping string array 'names' from point-to-cell conversion.",
+    ]
     assert result.cell_data.keys() == ['existing', 'values']
     assert result.cell_data['values'][0] == (0 if categorical else 1.25)
     assert result.cell_data['existing'][0] == 42

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -6,6 +6,7 @@ import re
 import sys
 from typing import Literal
 from typing import get_args
+from unittest.mock import Mock
 
 from hypothesis import HealthCheck
 from hypothesis import assume
@@ -1672,8 +1673,11 @@ def test_point_data_to_cell_data_strings_no_copies(monkeypatch, categorical):
         copies.append(copied)
         return copied
 
-    def forbid_copy(*_args, **_kwargs):
-        pytest.fail('Conversion must not copy the input or materialize string values.')
+    forbid_copy = Mock(
+        side_effect=AssertionError(
+            'Conversion must not copy the input or materialize string values.'
+        )
+    )
 
     with monkeypatch.context() as patch:
         patch.setattr(pv.DataObject, 'copy', check_copy)
@@ -1681,6 +1685,7 @@ def test_point_data_to_cell_data_strings_no_copies(monkeypatch, categorical):
         with pytest.warns(UserWarning, match="Dropping string array 'labels'"):
             result = mesh.point_data_to_cell_data(pass_point_data=True, categorical=categorical)
 
+    forbid_copy.assert_not_called()
     assert len(copies) == int(categorical)
     for copied in copies:
         assert np.shares_memory(copied.points, mesh.points)


### PR DESCRIPTION
Stacked on #9211. Applies the string array exclusion from that pull request to `cell_data_to_point_data()`, which VTK left inconsistent: string cell arrays were dropped silently for point sets and resolved positionally for structured types.

Both directions now share one exclusion, so a string array is reported once, left in the input, and passed through when `pass_cell_data=True`.

- `vtkStringArray` broke weight ties by list order, so the value a point received followed VTK's cell enumeration rather than the data: three of four cells agreeing still lost to the first one listed.
- Structured meshes no longer convert string cell arrays, so `cast_to_pointset(pass_cell_data=True)` and `cast_to_poly_points(pass_cell_data=True)` warn instead.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
